### PR TITLE
Clearing all translations enters reading mode

### DIFF
--- a/src/scripts/components/header/ContentDropdown.js
+++ b/src/scripts/components/header/ContentDropdown.js
@@ -13,7 +13,8 @@ class ContentDropdown extends React.Component {
 
     this.state = {
       options: [],
-      chosenOptions: this.context.getStore(UserStore).getContentOptions()
+      chosenOptions: this.context.getStore(UserStore).getContentOptions(),
+      toggled: false
     };
   }
 
@@ -28,7 +29,6 @@ class ContentDropdown extends React.Component {
 
   chosenOption(id, e) {
     let chosenOptions = this.state.chosenOptions;
-
     if (chosenOptions.find(x => x === id)) {
       chosenOptions.splice(
         chosenOptions.findIndex(x => x === id),
@@ -49,6 +49,21 @@ class ContentDropdown extends React.Component {
     this.context.executeAction(AyahsActions.updateAyahs, {
       content: chosenOptions
     });
+
+    if(chosenOptions.toString() === ''){
+      this.context.executeAction(AyahsActions.toggleReadingMode);
+      this.setState({
+        toggled: true
+      });
+      this.context.executeAction(ReadingModeToggle.renderIcon);
+    }
+
+    if(this.state.toggled === true && chosenOptions.toString() !== ''){
+      this.context.executeAction(AyahsActions.toggleReadingMode);
+      this.setState({
+        toggled: false
+      });
+    }
   }
 
   returnList(option) {

--- a/src/scripts/components/header/ContentDropdown.js
+++ b/src/scripts/components/header/ContentDropdown.js
@@ -50,14 +50,14 @@ class ContentDropdown extends React.Component {
       content: chosenOptions
     });
 
-    if(chosenOptions.toString() === ''){
+    if (chosenOptions.length === 0) {
       this.context.executeAction(AyahsActions.toggleReadingMode);
       this.setState({
         toggled: true
       });
     }
 
-    if(this.state.toggled === true && chosenOptions.toString() !== ''){
+    if (this.state.toggled === true && chosenOptions.length !== 0) {
       this.context.executeAction(AyahsActions.toggleReadingMode);
       this.setState({
         toggled: false

--- a/src/scripts/components/header/ContentDropdown.js
+++ b/src/scripts/components/header/ContentDropdown.js
@@ -55,7 +55,6 @@ class ContentDropdown extends React.Component {
       this.setState({
         toggled: true
       });
-      this.context.executeAction(ReadingModeToggle.renderIcon);
     }
 
     if(this.state.toggled === true && chosenOptions.toString() !== ''){


### PR DESCRIPTION
Deselecting all translations enters reading mode, manually re-entering a translation again brings back the translation view.