### PR TITLE
closes #215 - removes the information toggle icon from the desktop op…

### DIFF
--- a/src/scripts/components/header/DesktopOptions.js
+++ b/src/scripts/components/header/DesktopOptions.js
@@ -6,7 +6,7 @@ import ContentDropdown from 'components/header/ContentDropdown';
 import Audioplayer from 'components/audioplayer/Audioplayer';
 import FontSizeInput from 'components/header/FontSizeInput';
 import ReadingModeToggle from 'components/header/ReadingModeToggle';
-import InformationToggle from 'components/header/InformationToggle';
+import InformationToggle from 'components/header/InformationToggle'; // TODO: re-include with a non-wiki source
 import NavCollapseToggle from 'components/header/NavCollapseToggle';
 import debug from 'utils/Debug';
 
@@ -26,14 +26,11 @@ class DesktopOptions extends React.Component {
           <ContentDropdown />
           <div className="col-md-3 height-100">
             <div className="row">
-              <div className="col-md-6 height-100 border-right">
+              <div className="col-md-9 height-100 border-right">
                 <FontSizeInput />
               </div>
               <div className="col-md-3 text-center height-100">
                 <ReadingModeToggle />
-              </div>
-              <div className="col-md-3 text-center height-100">
-                <InformationToggle />
               </div>
             </div>
           </div>


### PR DESCRIPTION
…tions header

the intention here is to keep everything related to this feature readily available but just silently tucked away for when we have a non-wiki source or so that we can demo it if we need to in the interim