### PR TITLE
closes quran/quran.com-frontend#215 - removes the information toggle …

### DIFF
--- a/src/scripts/components/header/DesktopOptions.js
+++ b/src/scripts/components/header/DesktopOptions.js
@@ -6,7 +6,7 @@ import ContentDropdown from 'components/header/ContentDropdown';
 import Audioplayer from 'components/audioplayer/Audioplayer';
 import FontSizeInput from 'components/header/FontSizeInput';
 import ReadingModeToggle from 'components/header/ReadingModeToggle';
-import InformationToggle from 'components/header/InformationToggle';
+import InformationToggle from 'components/header/InformationToggle'; // TODO: re-include with a non-wiki source
 import NavCollapseToggle from 'components/header/NavCollapseToggle';
 import debug from 'utils/Debug';
 
@@ -26,14 +26,11 @@ class DesktopOptions extends React.Component {
           <ContentDropdown />
           <div className="col-md-3 height-100">
             <div className="row">
-              <div className="col-md-6 height-100 border-right">
+              <div className="col-md-9 height-100 border-right">
                 <FontSizeInput />
               </div>
               <div className="col-md-3 text-center height-100">
                 <ReadingModeToggle />
-              </div>
-              <div className="col-md-3 text-center height-100">
-                <InformationToggle />
               </div>
             </div>
           </div>


### PR DESCRIPTION
…icon from the desktop options header

the idea here is to quietly remove the info toggle icon but keep the code so that we can reuse it when we have a non-wiki source or demo it in the interim
PR @mmahalwy