### PR TITLE
closes quran/quran.com-frontend#214 - points the development proxy to…

### DIFF
--- a/development.env
+++ b/development.env
@@ -1,3 +1,3 @@
 PORT=8000
 CURRENT_URL=http://localhost:8000/api/
-API_URL=http://localhost:3000
+API_URL=http://api.quran.com:3000


### PR DESCRIPTION
… api.quran.com, so that essentially we by default do not assume that the frontend developer is running the backend code locally on his own machine