### PR TITLE
SEO/User friendly surah URL

### DIFF
--- a/src/components/SearchAutocomplete/index.js
+++ b/src/components/SearchAutocomplete/index.js
@@ -3,6 +3,8 @@ import ApiClient from '../../helpers/ApiClient';
 import { connect } from 'react-redux';
 import { push } from 'react-router-redux';
 
+import surahUrl from 'utils/SurahUrl';
+
 const client = new ApiClient();
 
 const styles = require('./style.scss');
@@ -93,7 +95,7 @@ export default class SearchAutocomplete extends Component {
     }
 
     this.setState({
-      surahs: matches.sort((a, b) => a[1] < b[1] ? -1 : 1).map((match) => ({text: `<b>${match[0]}</b>`, href: `/${match[1]}`})).slice(0, 5)
+      surahs: matches.sort((a, b) => a[1] < b[1] ? -1 : 1).map((match) => ({text: `<b>${match[0]}</b>`, href: `/${match[1]}`, name: match[0], id: match[1]})).slice(0, 5)
     });
   };
 
@@ -182,13 +184,13 @@ export default class SearchAutocomplete extends Component {
 
   renderList(key) {
     //this.handleItemKeyDown.bind({ item, self: this })
-    return this.state[key].map((item) => (
+    return this.state[key].map((item) =>(
       <li key={item.href} tabIndex="0" onKeyDown={((event) => { this.handleItemKeyDown.call(this, event, item); }).bind(this)}>
         <div className={styles.link}>
-          <a href={item.href} tabIndex="-1">{item.href}</a>
+          <a href={surahUrl(item.id, item.name)} tabIndex="-1">{item.href}</a>
         </div>
         <div className={styles.text}>
-          <a href={item.href} tabIndex="-1" dangerouslySetInnerHTML={{__html: item.text }} />
+          <a href={surahUrl(item.id, item.name)} tabIndex="-1" dangerouslySetInnerHTML={{__html: item.text }} />
         </div>
       </li>
     ));

--- a/src/components/SurahsDropdown/index.js
+++ b/src/components/SurahsDropdown/index.js
@@ -6,6 +6,8 @@ import Col from 'react-bootstrap/lib/Col';
 import DropdownButton from 'react-bootstrap/lib/DropdownButton';
 import MenuItem from 'react-bootstrap/lib/MenuItem';
 
+import surahUrl from 'utils/SurahUrl';
+
 const styles = require('./style.scss');
 
 export default class SurahsDropdown extends Component {
@@ -26,7 +28,7 @@ export default class SurahsDropdown extends Component {
     const { surahs } = this.props;
 
     return Object.values(surahs).map((surah, index) => (
-      <LinkContainer to={`/${surah.id}`} activeClass="active" key={`surah-${index}`}>
+      <LinkContainer to={surahUrl(surah.id, surah.nameSimple)} activeClass="active" key={`surah-${index}`}>
        <MenuItem>
           <Row>
             <Col xs={2} md={2}>

--- a/src/containers/Home/index.js
+++ b/src/containers/Home/index.js
@@ -8,6 +8,7 @@ import { connect } from 'react-redux';
 import moment from 'moment';
 
 import debug from 'utils/Debug';
+import surahUrl from 'utils/SurahUrl';
 
 import { isAllLoaded, loadAll } from '../../redux/modules/surahs';
 
@@ -32,7 +33,8 @@ class Home extends React.Component {
     return array.map((surah, i) => {
       return (
         <li className={`${styles.item}`} key={surah.id}>
-          <Link to={`/${surah.id}`} className={`${styles.link} row`}>
+
+          <Link to={`${surahUrl(surah.id, surah.nameSimple)}`} className={`${styles.link} row`}>
             <div className="col-xs-2 text-muted">
               {surah.id}
             </div>

--- a/src/containers/Surah/index.js
+++ b/src/containers/Surah/index.js
@@ -32,6 +32,8 @@ import makeHeadTags from '../../helpers/makeHeadTags';
 const style = require('./style.scss');
 
 import debug from 'utils/Debug';
+import surahUrl from 'utils/SurahUrl';
+
 
 import { clearCurrent, isLoaded, load as loadAyahs, setCurrentAyah, setCurrentWord, clearCurrentWord } from '../../redux/modules/ayahs';
 import { isAllLoaded, loadAll, setCurrent as setCurrentSurah } from '../../redux/modules/surahs';
@@ -52,7 +54,8 @@ const ayahRangeSize = 30;
   },
   {
     promise({ store: { dispatch, getState }, params }) {
-      const { range, surahId } = params;
+      const { range, surahId, surahName} = params;
+
       const { options } = getState();
       let from;
       let to;

--- a/src/routes.js
+++ b/src/routes.js
@@ -25,7 +25,9 @@ export default () => {
 
       <Route path="/search" component={Search} />
 
+      <Route path="/:surahName/:surahId(/:range)" component={Surah} />
       <Route path="/:surahId(/:range)" component={Surah} />
+
     </Route>
   );
 }

--- a/src/scripts/utils/SurahUrl.js
+++ b/src/scripts/utils/SurahUrl.js
@@ -1,0 +1,5 @@
+export default function(id, name) {
+  let surahName = name.toLowerCase().replace(/\W+/g, '-');
+
+  return `/${surahName}/${id}`;
+}


### PR DESCRIPTION
**WIP do not merge**

Salam, 

I am trying to get involved and I thought I'd tackle and minor issue I noticed. I think quran.com can benefit from include the surah name as part of the URL. For example currently `http://quran.com/2` for al-baqara, my suggestion is to have better and pretty urls like `http://quran.com/al-baqarah/2`. 

I am not an SEO guy, but I think the URL would be more identifiable when shared online, they are very user friendly and I am sure they can't harm in terms of SEO. 

This is a WIP as I explore all and change where possible. 

Let me know if you don't feel this is worth doing. 


checklist:

- [ ] use name as part of the URL or default to the id when surah name isn't available. 
- [ ] sitemap
- [ ] search and autosuggest (include ayah/range)
- [ ] quick links and footer surah links
- [ ] unit test surahUrl function
- [ ] nightwatch functional tests

