### PR TITLE
Bump babel-preset-es2015-webpack to 6.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "babel-plugin-typecheck": "^3.8.0",
     "babel-polyfill": "^6.7.4",
     "babel-preset-es2015": "^6.6.0",
-    "babel-preset-es2015-webpack": "^6.4.1",
+    "babel-preset-es2015-webpack": "^6.4.2",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-0": "^6.5.0",
     "babel-register": "^6.7.2",


### PR DESCRIPTION
Bumping this version to get a fix for a problem with 6.4.1 that throws
an error when using the preset.