### PR TITLE
Fix build issue with babel-preset-es2015

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "babel-plugin-transform-runtime": "^6.7.5",
     "babel-plugin-typecheck": "^3.8.0",
     "babel-polyfill": "^6.7.4",
-    "babel-preset-es2015": "^6.6.0",
+    "babel-preset-es2015": "~6.9.0",
     "babel-preset-es2015-webpack": "^6.4.1",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-0": "^6.5.0",


### PR DESCRIPTION
babel-preset-es2015 6.13.1 causes issues with
babel-preset-es2015-webpack, so this freezes the dependency of
babel-preset-es2105 to 6.9.0.