### PR TITLE
Upgrade express to the latest stable version

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "debug": "^2.2.0",
     "dotenv": "^1.2.0",
     "errorhandler": "^1.4.2",
-    "express": "^4.3.2",
+    "express": "~4.14.0",
     "express-state": "^1.2.0",
     "express-useragent": "^0.2.0",
     "extract-text-webpack-plugin": "2.0.0-beta.3",


### PR DESCRIPTION
Express 4.3.2, which we use, has a vulnerability. The stable version
should not have this vulnerability (the version we are using is very
old, from 2014).