### PR TITLE
Let pm2 automagically choose the number of workers

### DIFF
--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -2,7 +2,7 @@
 nodaemon=true
 
 [program:pm2]
-command=pm2 start /quran/start.js -i 4 --no-daemon
+command=pm2 start /quran/start.js -i 0 --no-daemon
 directory=/quran
 redirect_stderr=true
 stdout_logfile=/dev/stdout


### PR DESCRIPTION
Setting -i of 0 lets pm2 choose to start as many workers as there are
cores, which is better than manually choosing 4. Fixes #445.