### PR TITLE
Remove supported check for audio

### DIFF
--- a/src/components/Audioplayer/index.js
+++ b/src/components/Audioplayer/index.js
@@ -27,7 +27,6 @@ export class Audioplayer extends Component {
     currentAyah: PropTypes.string,
     buildOnClient: PropTypes.func.isRequired,
     isLoadedOnClient: PropTypes.bool.isRequired,
-    isSupported: PropTypes.bool.isRequired,
     isLoading: PropTypes.bool.isRequired,
     play: PropTypes.func.isRequired,
     pause: PropTypes.func.isRequired,
@@ -381,7 +380,6 @@ export class Audioplayer extends Component {
       isLoading,
       currentAyah,
       currentTime,
-      isSupported,
       duration,
       surah,
       isLoadedOnClient,
@@ -389,14 +387,6 @@ export class Audioplayer extends Component {
       shouldScroll, // eslint-disable-line no-shadow
       setRepeat // eslint-disable-line no-shadow
     } = this.props;
-
-    if (!isSupported) {
-      return (
-        <li className={`${style.container} ${className}`}>
-          Your browser does not support this audio.
-        </li>
-      );
-    }
 
     if (isLoading) {
       return (
@@ -458,7 +448,6 @@ const mapStateToProps = (state, ownProps) => ({
   currentFile: state.audioplayer.currentFile,
   currentAyah: state.audioplayer.currentAyah,
   surahId: state.audioplayer.surahId,
-  isSupported: state.audioplayer.isSupported,
   isPlaying: state.audioplayer.isPlaying,
   isLoadedOnClient: state.audioplayer.isLoadedOnClient,
   isLoading: state.audioplayer.isLoading,

--- a/src/redux/modules/audioplayer.js
+++ b/src/redux/modules/audioplayer.js
@@ -34,7 +34,6 @@ const initialState = {
   currentAyah: null,
   currentWord: null,
   currentTime: 0,
-  isSupported: true,
   isPlaying: false,
   repeat: {
     from: undefined,
@@ -92,16 +91,6 @@ export default function reducer(state = initialState, action = {}) {
     }
     case AYAHS_LOAD_SUCCESS: {
       debug('reducer:audioplayer', 'AYAHS_LOAD_SUCCESS init');
-      let currentFile;
-      const isSupported =
-        action.result.entities.ayahs[action.result.result[0]] != null;
-
-      if (!isSupported) {
-        return {
-          ...state,
-          isSupported: false
-        };
-      }
 
       const ayahs = action.result.entities.ayahs;
       const audioFromHash = __CLIENT__ ? buildAudioFromHash(ayahs, state.userAgent) : ayahs;
@@ -113,6 +102,7 @@ export default function reducer(state = initialState, action = {}) {
 
       const currentAyah = state.currentAyah ? state.currentAyah : Object.keys(files)[0];
 
+      let currentFile;
       if (state.currentFile && state.currentFile === Object.values(files)[0]) {
         // If the same file is being used, for example in lazy loading, then keep same file
         currentFile = state.currentFile;
@@ -133,7 +123,6 @@ export default function reducer(state = initialState, action = {}) {
       debug('reducer:audioplayer', 'AYAHS_LOAD_SUCCESS return');
       return {
         ...state,
-        isSupported,
         currentAyah,
         currentFile,
         surahId: action.surahId,


### PR DESCRIPTION
Previously, we had to check whether or not audio was of a supported
format, since most of our audio files were ogg only (which wouldn't work
on Safari and other browsers). Since we are now using mp3s for
everything, we no longer need these checks.