### PR TITLE
Replace bootstrap tooltips with CSS ones

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -15,7 +15,7 @@ import { syncHistoryWithStore } from 'react-router-redux';
 
 import debug from 'debug';
 
-import config from 'config';
+import config from './config';
 import ApiClient from './helpers/ApiClient';
 import createStore from './redux/create';
 import routes from './routes';

--- a/src/client.js
+++ b/src/client.js
@@ -40,16 +40,6 @@ window.clearCookies = () => {
   reactCookie.remove('isFirstTime');
 };
 
-// Init tooltip
-if (typeof window !== 'undefined') {
-  $(() => {
-    $(document.body).tooltip({
-      selector: '[data-toggle="tooltip"]',
-      animation: false
-    });
-  });
-}
-
 match({ history, routes: routes() }, (error, redirectLocation, renderProps) => {
   const component = (
     <Router

--- a/src/components/Ayah/index.js
+++ b/src/components/Ayah/index.js
@@ -8,11 +8,13 @@ import debug from '../../helpers/debug';
 
 const styles = require('./style.scss');
 
+/* eslint-disable no-unused-vars */
 const CHAR_TYPE_WORD = 1;
-const CHAR_TYPE_END = 2; // eslint-disable-line no-unused-vars
-const CHAR_TYPE_PAUSE = 3; // eslint-disable-line no-unused-vars
-const CHAR_TYPE_RUB = 4; // eslint-disable-line no-unused-vars
-const CHAR_TYPE_SAJDAH = 5; // eslint-disable-line no-unused-vars
+const CHAR_TYPE_END = 2;
+const CHAR_TYPE_PAUSE = 3;
+const CHAR_TYPE_RUB = 4;
+const CHAR_TYPE_SAJDAH = 5;
+/* eslint-enable no-unused-vars */
 
 export default class Ayah extends Component {
   static propTypes = {
@@ -92,7 +94,7 @@ export default class Ayah extends Component {
     let position = -1;
     let text = ayah.words.map(word => {
       let id = null;
-      const className = `${word.className} ${word.highlight && word.highlight}`;
+      const className = `${word.className} ${word.highlight ? word.highlight : ''}`;
 
       if (word.charTypeId === CHAR_TYPE_WORD) {
         position = position + 1;
@@ -110,12 +112,8 @@ export default class Ayah extends Component {
             id={id}
             onClick={(event) => onWordClick(event.target.dataset.key)}
             data-key={`${word.ayahKey}:${position}`}
-            className={`${className} pointer`}
-            data-toggle="tooltip"
-            data-trigger="hover"
-            data-placement="top"
-            data-original-title={tooltipContent}
-            title={tooltipContent}
+            className={`${className} ${styles.Tooltip}`}
+            aria-label={tooltipContent}
             dangerouslySetInnerHTML={{__html: word.code}}
           />
         );

--- a/src/components/Ayah/style.scss
+++ b/src/components/Ayah/style.scss
@@ -1,4 +1,5 @@
-@import '../../styles/variables.scss';
+@import '../../styles/variables';
+@import '../../styles/partials/_tooltip';
 
 .container{
   padding: 2.5% 0%;
@@ -84,7 +85,7 @@
   color: #000;
   width: 100%;
   overflow-wrap: break-word;
-  line-height: 150%;
+  line-height: 1.5;
   word-break: break-all;
   text-align: right;
   float: left;
@@ -101,9 +102,10 @@
   }
 
   .line{
+    direction: rtl;
     b{
       float: none;
-      display: inline;
+      display: inline-block;
     }
   }
 
@@ -114,7 +116,7 @@
     color: #000;
     &:hover{
       color: $brand-primary;
-      cursor: pointer;
+      cursor: help;
     }
     &:focus{
       color: $brand-primary-darker-10;

--- a/src/components/Line/index.js
+++ b/src/components/Line/index.js
@@ -23,15 +23,12 @@ export default class Line extends React.Component {
         return (
           <b
             key={`${word.pageNum}${word.lineNum}${word.position}${word.code}`}
-            className={`${word.className} pointer`}
-            data-toggle="tooltip"
+            className={`${word.className} ${styles.Tooltip}`}
             data-ayah={word.ayahKey}
             data-line={word.lineNun}
             data-page={word.pageNum}
             data-position={word.position}
-            data-placement="top"
-            data-origin-title={tooltipContent}
-            title={tooltipContent}
+            aria-label={tooltipContent}
             dangerouslySetInnerHTML={{__html: word.code}}
           />
         );

--- a/src/styles/partials/_tooltip.scss
+++ b/src/styles/partials/_tooltip.scss
@@ -1,9 +1,42 @@
-.tooltip{
-  font-size: 16px;
-  font-weight: 300;
-  @extend .montserrat;
+.Tooltip {
+  position: relative;
 
-  .tooltip-inner{
-    padding: 10px 15px;
+  &:after {
+    content: attr(aria-label);
+    padding: .625rem .9375rem;
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    transform: translate(-50%, 0);
+    font-family: Montserrat, sans-serif;
+    font-weight: 300;
+    font-size: 1.25rem;
+    line-height: 1.2;
+    background-color: $tooltip-bg;
+    color: #fff;
+    border-radius: 3px;
+    opacity: 0;
+  }
+
+  // The arrow
+  &:before {
+    content: '';
+    position: absolute;
+    left: 50%;
+    transform: translate(-50%, 0);
+    width: 0;
+    height: 0;
+    border-left: .75rem solid transparent;
+    border-right: .75rem solid transparent;
+    border-top: .75rem solid $tooltip-bg;
+    opacity: 0;
+  }
+
+
+  &:hover {
+    &:after,
+    &:before {
+      opacity: 1;
+    }
   }
 }


### PR DESCRIPTION
I replaced the Ayah tooltip from using jQuery & bootstrap tooltips to use just CSS. I only managed to find it used in two places `<Ayah />` & `<Line />` so if it's used somewhere else please let me know.

**Some stuff I noticed while working on this**

- CSS is done in multiple different ways that it's very hard to reason about things. `Normal Sass, CSS modules & some bootstrap magic`
- Can we get rid of Bootstrap completely? for layout components this is very lightweight & doesn't add load of CSS http://jxnblk.com/rebass/
- No usage of `dir="rtl"` or `lang="ar"` attributes on any HTML which kind of forces some kind of CSS hacks to align text & stuff.