### PR TITLE
Issue  #472: Added tooltip prop for Ayah component in Search page

### DIFF
--- a/src/containers/Search/index.js
+++ b/src/containers/Search/index.js
@@ -109,7 +109,7 @@ class Search extends Component {
   }
 
   renderBody() {
-    const { isErrored, isLoading, total, results, ayahs } = this.props;
+    const { isErrored, isLoading, total, results,options, ayahs } = this.props;
 
     if (isErrored) {
       return (
@@ -128,7 +128,7 @@ class Search extends Component {
     }
 
     return results.map(result => (
-      <Ayah ayah={ayahs[result.ayah]} match={result.match} key={result.ayah} isSearched />
+      <Ayah ayah={ayahs[result.ayah]} match={result.match} key={result.ayah} tooltip={options.tooltip} isSearched />
     ));
   }
 


### PR DESCRIPTION
Looks like an easy fix by just adding the missing tooltip prop in `Ayah` component. 