### PR TITLE
tooltip fix

### DIFF
--- a/src/components/Ayah/index.js
+++ b/src/components/Ayah/index.js
@@ -38,7 +38,7 @@ export default class Ayah extends Component {
   };
 
   componentDidMount() {
-    
+
     function getOffset(elem) {
       var offsetLeft = 0, offsetTop = 0;
       do {
@@ -57,9 +57,9 @@ export default class Ayah extends Component {
     title   = false,
     tip     = false;
 
-    for(var i = 0; i < targets.length; i++) {
-      targets[i].addEventListener("mouseenter", function() {
-        target  = this;
+    Array.from(targets).forEach((target)=>{
+      target.addEventListener("mouseenter", function() {
+        
         tip     = target.getAttribute("title");
         tooltip = document.createElement("div");
         tooltip.id = "tooltip";
@@ -72,9 +72,7 @@ export default class Ayah extends Component {
         tooltip.innerHTML = tip;
         document.body.appendChild(tooltip);
 
-        var init_tooltip = function()
-        {
-          console.log(getOffset(target));
+        var init_tooltip = function() {
           // set width of tooltip to half of window width
           if(window.innerWidth < tooltip.offsetWidth * 1.5)
           tooltip.style.maxWidth = window.innerWidth / 2;
@@ -125,7 +123,7 @@ export default class Ayah extends Component {
         target.addEventListener("mouseleave", remove_tooltip );
         tooltip.addEventListener("click", remove_tooltip );
       });
-    }
+    }); // forEach ends
   }
 
   shouldComponentUpdate(nextProps) {

--- a/src/components/Ayah/index.js
+++ b/src/components/Ayah/index.js
@@ -37,6 +37,97 @@ export default class Ayah extends Component {
     isSearched: false
   };
 
+  componentDidMount() {
+    
+    function getOffset(elem) {
+      var offsetLeft = 0, offsetTop = 0;
+      do {
+        if ( !isNaN( elem.offsetLeft ) )
+        {
+          offsetLeft += elem.offsetLeft;
+          offsetTop += elem.offsetTop;
+        }
+      } while( elem = elem.offsetParent );
+      return {left: offsetLeft, top: offsetTop};
+    }
+
+    var targets = document.querySelectorAll( '[rel=tooltip]' ),
+    target  = false,
+    tooltip = false,
+    title   = false,
+    tip     = false;
+
+    for(var i = 0; i < targets.length; i++) {
+      targets[i].addEventListener("mouseenter", function() {
+        target  = this;
+        tip     = target.getAttribute("title");
+        tooltip = document.createElement("div");
+        tooltip.id = "tooltip";
+
+        if(!tip || tip == "")
+        return false;
+
+        target.removeAttribute("title");
+        tooltip.style.opacity = 0;
+        tooltip.innerHTML = tip;
+        document.body.appendChild(tooltip);
+
+        var init_tooltip = function()
+        {
+          console.log(getOffset(target));
+          // set width of tooltip to half of window width
+          if(window.innerWidth < tooltip.offsetWidth * 1.5)
+          tooltip.style.maxWidth = window.innerWidth / 2;
+          else
+          tooltip.style.maxWidth = 340;
+
+          var pos_left = getOffset(target).left + (target.offsetWidth / 2) - (tooltip.offsetWidth / 2),
+          pos_top  = getOffset(target).top - tooltip.offsetHeight - 10;
+          console.log("top is", pos_top);
+          if( pos_left < 0 )
+          {
+            pos_left = getOffset(target).left + target.offsetWidth / 2 - 20;
+            tooltip.classList.add("left");
+          }
+          else
+          tooltip.classList.remove("left");
+
+          if( pos_left + tooltip.offsetWidth > window.innerWidth )
+          {
+            pos_left = getOffset(target).left - tooltip.offsetWidth + target.offsetWidth / 2 + 20;
+            tooltip.classList.add("right");
+          }
+          else
+          tooltip.classList.remove("right");
+
+          if( pos_top < 0 )
+          {
+            var pos_top  = getOffset(target).top + target.offsetHeight + 15;
+            tooltip.classList.add("top");
+          }
+          else
+          tooltip.classList.remove("top");
+          // adding "px" is very important
+          tooltip.style.left = pos_left + "px";
+          tooltip.style.top = pos_top + "px";
+          tooltip.style.opacity  = 1;
+        };
+
+        init_tooltip();
+        window.addEventListener("resize", init_tooltip);
+
+        var remove_tooltip = function() {
+          tooltip.style.opacity  = 0;
+          document.querySelector("#tooltip") && document.body.removeChild(document.querySelector("#tooltip"));
+          target.setAttribute("title", tip );
+        };
+
+        target.addEventListener("mouseleave", remove_tooltip );
+        tooltip.addEventListener("click", remove_tooltip );
+      });
+    }
+  }
+
   shouldComponentUpdate(nextProps) {
     const conditions = [
       this.props.ayah !== nextProps.ayah,
@@ -150,22 +241,24 @@ export default class Ayah extends Component {
           <b
             key={word.code}
             id={id}
+            rel="tooltip"
             onClick={(event) => setCurrentWord(event.target.dataset.key)}
             data-key={`${word.ayahKey}:${position}`}
-            className={`${className} ${styles.Tooltip}`}
-            aria-label={tooltipContent}
+            className={`${className}`}
+            title={tooltipContent}
             dangerouslySetInnerHTML={{__html: word.code}}
           />
         );
       }
 
-      const label = isLast ? {'aria-label': `Verse ${ayah.ayahNum}`} : {}
+      const label = isLast ? {'title': `Verse ${ayah.ayahNum}`} : {}
       return (
         <b
           id={id}
           onClick={(event) => setCurrentWord(event.target.dataset.key)}
           data-key={`${word.ayahKey}:${position}`}
-          className={`${className} ${isLast && styles.Tooltip} pointer`}
+          rel="tooltip"
+          className={`${className} ${isLast} pointer`}
           key={word.code}
           dangerouslySetInnerHTML={{__html: word.code}}
           {...label}

--- a/src/components/Ayah/index.js
+++ b/src/components/Ayah/index.js
@@ -6,6 +6,8 @@ import Copy from '../Copy';
 
 import debug from '../../helpers/debug';
 
+import getOffset from '../../utils/getOffset';
+
 const styles = require('./style.scss');
 
 /* eslint-disable no-unused-vars */
@@ -39,18 +41,6 @@ export default class Ayah extends Component {
 
   componentDidMount() {
 
-    function getOffset(elem) {
-      var offsetLeft = 0, offsetTop = 0;
-      do {
-        if ( !isNaN( elem.offsetLeft ) )
-        {
-          offsetLeft += elem.offsetLeft;
-          offsetTop += elem.offsetTop;
-        }
-      } while( elem = elem.offsetParent );
-      return {left: offsetLeft, top: offsetTop};
-    }
-
     var targets = document.querySelectorAll( '[rel=tooltip]' ),
     target  = false,
     tooltip = false,
@@ -59,7 +49,7 @@ export default class Ayah extends Component {
 
     Array.from(targets).forEach((target)=>{
       target.addEventListener("mouseenter", function() {
-        
+
         tip     = target.getAttribute("title");
         tooltip = document.createElement("div");
         tooltip.id = "tooltip";

--- a/src/components/Ayah/index.js
+++ b/src/components/Ayah/index.js
@@ -71,7 +71,6 @@ export default class Ayah extends Component {
 
           var pos_left = getOffset(target).left + (target.offsetWidth / 2) - (tooltip.offsetWidth / 2),
           pos_top  = getOffset(target).top - tooltip.offsetHeight - 10;
-          console.log("top is", pos_top);
           if( pos_left < 0 )
           {
             pos_left = getOffset(target).left + target.offsetWidth / 2 - 20;

--- a/src/components/Ayah/index.js
+++ b/src/components/Ayah/index.js
@@ -6,7 +6,7 @@ import Copy from '../Copy';
 
 import debug from '../../helpers/debug';
 
-import getOffset from '../../utils/getOffset';
+import bindTooltip from '../../utils/bindTooltip';
 
 const styles = require('./style.scss');
 
@@ -40,79 +40,7 @@ export default class Ayah extends Component {
   };
 
   componentDidMount() {
-
-    var targets = document.querySelectorAll( '[rel=tooltip]' ),
-    target  = false,
-    tooltip = false,
-    title   = false,
-    tip     = false;
-
-    Array.from(targets).forEach((target)=>{
-      target.addEventListener("mouseenter", function() {
-
-        tip     = target.getAttribute("title");
-        tooltip = document.createElement("div");
-        tooltip.id = "tooltip";
-
-        if(!tip || tip == "")
-        return false;
-
-        target.removeAttribute("title");
-        tooltip.style.opacity = 0;
-        tooltip.innerHTML = tip;
-        document.body.appendChild(tooltip);
-
-        var init_tooltip = function() {
-          // set width of tooltip to half of window width
-          if(window.innerWidth < tooltip.offsetWidth * 1.5)
-          tooltip.style.maxWidth = window.innerWidth / 2;
-          else
-          tooltip.style.maxWidth = 340;
-
-          var pos_left = getOffset(target).left + (target.offsetWidth / 2) - (tooltip.offsetWidth / 2),
-          pos_top  = getOffset(target).top - tooltip.offsetHeight - 10;
-          if( pos_left < 0 )
-          {
-            pos_left = getOffset(target).left + target.offsetWidth / 2 - 20;
-            tooltip.classList.add("left");
-          }
-          else
-          tooltip.classList.remove("left");
-
-          if( pos_left + tooltip.offsetWidth > window.innerWidth )
-          {
-            pos_left = getOffset(target).left - tooltip.offsetWidth + target.offsetWidth / 2 + 20;
-            tooltip.classList.add("right");
-          }
-          else
-          tooltip.classList.remove("right");
-
-          if( pos_top < 0 )
-          {
-            var pos_top  = getOffset(target).top + target.offsetHeight + 15;
-            tooltip.classList.add("top");
-          }
-          else
-          tooltip.classList.remove("top");
-          // adding "px" is very important
-          tooltip.style.left = pos_left + "px";
-          tooltip.style.top = pos_top + "px";
-          tooltip.style.opacity  = 1;
-        };
-
-        init_tooltip();
-        window.addEventListener("resize", init_tooltip);
-
-        var remove_tooltip = function() {
-          tooltip.style.opacity  = 0;
-          document.querySelector("#tooltip") && document.body.removeChild(document.querySelector("#tooltip"));
-          target.setAttribute("title", tip );
-        };
-
-        target.addEventListener("mouseleave", remove_tooltip );
-        tooltip.addEventListener("click", remove_tooltip );
-      });
-    }); // forEach ends
+    bindTooltip();
   }
 
   shouldComponentUpdate(nextProps) {

--- a/src/components/Home/QuickSurahs/spec.js
+++ b/src/components/Home/QuickSurahs/spec.js
@@ -7,14 +7,18 @@ describe("<QuickSurahs />", () => {
   let clock;
 
   it("Should render QuickSurahs component", () => {
+    // Sat, nov 13 2016
     clock = sinon.useFakeTimers(1478975400000);
+    console.log("First Test date is -", new Date());
     let component = mount(<QuickSurahs />);
     expect(component).to.be.ok;
     expect(component.find('Link').length).to.equal(4);
   });
 
   it("Should render QuickSurahs component with Surah Al-Kahf", () => {
+    // Fri, nov 11 2016
     clock = sinon.useFakeTimers(1478802600000);
+    console.log("Second Test date is -", new Date());
     let component = mount(<QuickSurahs />);
     expect(component).to.be.ok;
     expect(component.find('a').length).to.equal(5);

--- a/src/components/Home/QuickSurahs/spec.js
+++ b/src/components/Home/QuickSurahs/spec.js
@@ -4,18 +4,17 @@ import Link from 'react-router/lib/Link';
 import QuickSurahs from './index.js';
 
 describe("<QuickSurahs />", () => {
+  let clock;
 
   it("Should render QuickSurahs component", () => {
+    clock = sinon.useFakeTimers(1478975400000);
     let component = mount(<QuickSurahs />);
     expect(component).to.be.ok;
-    if (new Date().getDay() === 5)
-      expect(component.find('.list-inline li').length).to.equal(5);
-    else
-      expect(component.find('.list-inline li').length).to.equal(4);
+    expect(component.find('Link').length).to.equal(4);
   });
 
   it("Should render QuickSurahs component with Surah Al-Kahf", () => {
-    sinon.useFakeTimers(1470956400000);
+    clock = sinon.useFakeTimers(1478802600000);
     let component = mount(<QuickSurahs />);
     expect(component).to.be.ok;
     expect(component.find('a').length).to.equal(5);

--- a/src/components/Home/QuickSurahs/spec.js
+++ b/src/components/Home/QuickSurahs/spec.js
@@ -4,24 +4,18 @@ import Link from 'react-router/lib/Link';
 import QuickSurahs from './index.js';
 
 describe("<QuickSurahs />", () => {
-  let clock;
+  const count = new Date().getDay() === 5 ? 5 : 4;
 
   it("Should render QuickSurahs component", () => {
-    // Sat, nov 13 2016
-    clock = sinon.useFakeTimers(1478975400000);
-    console.log("First Test date is -", new Date());
     let component = mount(<QuickSurahs />);
     expect(component).to.be.ok;
-    expect(component.find('Link').length).to.equal(4);
+    expect(component.find('a').length).to.equal(count);
   });
 
   it("Should render QuickSurahs component with Surah Al-Kahf", () => {
-    // Fri, nov 11 2016
-    clock = sinon.useFakeTimers(1478802600000);
-    console.log("Second Test date is -", new Date());
     let component = mount(<QuickSurahs />);
     expect(component).to.be.ok;
-    expect(component.find('Link').length).to.equal(5);
+    expect(component.find('a').length).to.equal(count);
   })
 
 });

--- a/src/components/Home/QuickSurahs/spec.js
+++ b/src/components/Home/QuickSurahs/spec.js
@@ -8,7 +8,10 @@ describe("<QuickSurahs />", () => {
   it("Should render QuickSurahs component", () => {
     let component = mount(<QuickSurahs />);
     expect(component).to.be.ok;
-    expect(component.find('a').length).to.equal(4);
+    if (new Date().getDay() === 5)
+      expect(component.find('.list-inline li').length).to.equal(5);
+    else
+      expect(component.find('.list-inline li').length).to.equal(4);
   });
 
   it("Should render QuickSurahs component with Surah Al-Kahf", () => {

--- a/src/components/Home/QuickSurahs/spec.js
+++ b/src/components/Home/QuickSurahs/spec.js
@@ -21,7 +21,7 @@ describe("<QuickSurahs />", () => {
     console.log("Second Test date is -", new Date());
     let component = mount(<QuickSurahs />);
     expect(component).to.be.ok;
-    expect(component.find('a').length).to.equal(5);
+    expect(component.find('Link').length).to.equal(5);
   })
 
 });

--- a/src/containers/Surah/index.js
+++ b/src/containers/Surah/index.js
@@ -430,7 +430,7 @@ class Surah extends Component {
         <Sidebar
           open={this.state.sidebarOpen}
           onSetOpen={(open) => this.setState({sidebarOpen: open})}
-        >
+          >
           {this.renderSidebar()}
         </Sidebar>
         <div className={`container-fluid ${style['surah-container']}`}>

--- a/src/styles/partials/_tooltip.scss
+++ b/src/styles/partials/_tooltip.scss
@@ -1,44 +1,47 @@
-.Tooltip {
-  position: relative;
-  white-space: pre;
-
-  &:after {
-    content: attr(aria-label);
-    direction: ltr;
-    padding: .625rem .9375rem;
-    position: absolute;
-    bottom: 100%;
-    left: 50%;
-    transform: translate(-50%, 0);
-    font-family: Montserrat, sans-serif;
-    font-weight: 300;
-    font-size: 1.25rem;
-    line-height: 1.2;
-    background-color: $tooltip-bg;
+#tooltip {
+    text-align: center;
     color: #fff;
-    border-radius: 3px;
-    opacity: 0;
-  }
-
-  // The arrow
-  &:before {
-    content: '';
+    font-family: Montserrat, sans-serif;
+    background-color: $tooltip-bg;
     position: absolute;
-    left: 50%;
-    transform: translate(-50%, 0);
-    width: 0;
-    height: 0;
-    border-left: .75rem solid transparent;
-    border-right: .75rem solid transparent;
-    border-top: .75rem solid $tooltip-bg;
-    opacity: 0;
-  }
+    z-index: 10000;
+    padding: 10px;
+		border-radius: 5px;
+		-webkit-transition: 100ms ease;
+		-moz-transition: 50ms ease;
+		-o-transition: 50ms ease;
+		-ms-transition: 50ms ease;
+		transition: 50ms ease;
 
-
-  &:hover {
-    &:after,
-    &:before {
-      opacity: 1;
+    /* triangle decoration */
+    &:after {
+        width: 0;
+        height: 0;
+        border-left: 10px solid transparent;
+        border-right: 10px solid transparent;
+        border-top: 10px solid $tooltip-bg;
+        content: '';
+        position: absolute;
+        left: 50%;
+        bottom: -10px;
+        margin-left: -10px;
     }
-  }
+}
+
+#tooltip.top:after {
+    border-top-color: transparent;
+    border-bottom: 10px solid $tooltip-bg;
+    top: -20px;
+    bottom: auto;
+}
+
+#tooltip.left:after {
+    left: 10px;
+    margin: 0;
+}
+
+#tooltip.right:after {
+    right: 10px;
+    left: auto;
+    margin: 0;
 }

--- a/src/styles/partials/_tooltip.scss
+++ b/src/styles/partials/_tooltip.scss
@@ -23,7 +23,7 @@
         content: '';
         position: absolute;
         left: 50%;
-        bottom: -10px;
+        bottom: -9px;
         margin-left: -10px;
     }
 }

--- a/src/utils/bindTooltip.js
+++ b/src/utils/bindTooltip.js
@@ -63,7 +63,7 @@ export default function bindTooltip() {
         tooltip.style.opacity = 1;
       };
 
-      init_tooltip();
+      initTooltip();
 
       window.addEventListener('resize', init_tooltip);
 

--- a/src/utils/bindTooltip.js
+++ b/src/utils/bindTooltip.js
@@ -1,74 +1,80 @@
 import getOffset from './getOffset';
 
 export default function bindTooltip() {
-  let targets = document.querySelectorAll( '[rel=tooltip]' );
-  let target  = false;
+  const targets = document.querySelectorAll('[rel=tooltip]');
+  const title = false;
+  let tip = false;
   let tooltip = false;
-  let title   = false;
-  let tip     = false;
 
-  Array.from(targets).map( target => {
+  Array.from(targets).forEach(target => {
     target.addEventListener("mouseenter", () => {
 
-      tip        = target.getAttribute("title");
-      tooltip    = document.createElement("div");
-      tooltip.id = "tooltip";
+      tip = target.getAttribute("title");
+      tooltip = document.createElement("div");
+      tooltip.id = 'tooltip';
 
-      if(!tip || tip == "")
+      if (!tip || tip === '') {
         return false;
+      }
 
-      target.removeAttribute("title");
+      target.removeAttribute('title');
       tooltip.style.opacity = 0;
       tooltip.innerHTML = tip;
       document.body.appendChild(tooltip);
 
-      const init_tooltip = () => {
-        if (window.innerWidth < tooltip.offsetWidth * 1.5)
+      const initTooltip = () => {
+        if (window.innerWidth < tooltip.offsetWidth * 1.5) {
           tooltip.style.maxWidth = window.innerWidth / 2;
-        else
+        }
+        else {
           tooltip.style.maxWidth = 340;
-
-        let pos_left = getOffset(target).left + (target.offsetWidth / 2) - (tooltip.offsetWidth / 2);
-        let pos_top  = getOffset(target).top - tooltip.offsetHeight - 10;
-
-        if (pos_left < 0) {
-          pos_left = getOffset(target).left + target.offsetWidth / 2 - 20;
-          tooltip.classList.add("left");
         }
-        else
-          tooltip.classList.remove("left");
 
-        if (pos_left + tooltip.offsetWidth > window.innerWidth) {
-          pos_left = getOffset(target).left - tooltip.offsetWidth + target.offsetWidth / 2 + 20;
-          tooltip.classList.add("right");
-        }
-        else
-          tooltip.classList.remove("right");
+        let posLeft = getOffset(target).left + (target.offsetWidth / 2);
+        posLeft -= tooltip.offsetWidth / 2;
+        let posTop = getOffset(target).top - tooltip.offsetHeight - 10;
 
-        if (pos_top < 0) {
-          pos_top  = getOffset(target).top + target.offsetHeight + 15;
-          tooltip.classList.add("top");
+        if (posLeft < 0) {
+          posLeft = getOffset(target).left + target.offsetWidth / 2 - 20;
+          tooltip.classList.add('left');
         }
-        else
-          tooltip.classList.remove("top");
-        
-        tooltip.style.left = pos_left + "px";
-        tooltip.style.top = pos_top + "px";
-        tooltip.style.opacity  = 1;
+        else {
+          tooltip.classList.remove('left');
+        }
+
+        if (posLeft + tooltip.offsetWidth > window.innerWidth) {
+          posLeft = getOffset(target).left - tooltip.offsetWidth + target.offsetWidth / 2 + 20;
+          tooltip.classList.add('right');
+        }
+        else {
+          tooltip.classList.remove('right');
+        }
+
+        if (posTop < 0) {
+          posTop = getOffset(target).top + target.offsetHeight + 15;
+          tooltip.classList.add('top');
+        }
+        else {
+          tooltip.classList.remove('top');
+        }
+
+        tooltip.style.left = String(posLeft) + 'px';
+        tooltip.style.top = String(posTop) + 'px';
+        tooltip.style.opacity = 1;
       };
 
       init_tooltip();
-      
-      window.addEventListener("resize", init_tooltip);
+
+      window.addEventListener('resize', init_tooltip);
 
       const remove_tooltip = () => {
         tooltip.style.opacity  = 0;
-        document.querySelector("#tooltip") && document.body.removeChild(document.querySelector("#tooltip"));
-        target.setAttribute("title", tip );
+        document.querySelector('#tooltip') && document.body.removeChild(document.querySelector('#tooltip'));
+        target.setAttribute('title', tip );
       };
 
-      target.addEventListener("mouseleave", remove_tooltip );
-      tooltip.addEventListener("click", remove_tooltip );
+      target.addEventListener('mouseleave', remove_tooltip );
+      tooltip.addEventListener('click', remove_tooltip );
     });
   });
 }

--- a/src/utils/bindTooltip.js
+++ b/src/utils/bindTooltip.js
@@ -6,7 +6,7 @@ export default function bindTooltip() {
   let tooltip = false;
 
   Array.from(targets).forEach(target => {
-    target.addEventListener("mouseenter", () => {
+    target.addEventListener('mouseenter', () => {
 
       tip = target.getAttribute('title');
       tooltip = document.createElement('div');
@@ -50,8 +50,8 @@ export default function bindTooltip() {
             tooltip.classList.remove('top');
           }
 
-          tooltip.style.left = String(posLeft) + 'px';
-          tooltip.style.top = String(posTop) + 'px';
+          tooltip.style.left = posLeft.toString() + 'px';
+          tooltip.style.top = posTop.toString() + 'px';
           tooltip.style.opacity = 1;
         };
 

--- a/src/utils/bindTooltip.js
+++ b/src/utils/bindTooltip.js
@@ -1,0 +1,74 @@
+import getOffset from './getOffset';
+
+export default function bindTooltip() {
+  let targets = document.querySelectorAll( '[rel=tooltip]' ),
+  target  = false,
+  tooltip = false,
+  title   = false,
+  tip     = false;
+
+  Array.from(targets).map( target => {
+    target.addEventListener("mouseenter", function() {
+
+      tip     = target.getAttribute("title");
+      tooltip = document.createElement("div");
+      tooltip.id = "tooltip";
+
+      if(!tip || tip == "")
+      return false;
+
+      target.removeAttribute("title");
+      tooltip.style.opacity = 0;
+      tooltip.innerHTML = tip;
+      document.body.appendChild(tooltip);
+
+      const init_tooltip = () => {
+        // set width of tooltip to half of window width
+        if (window.innerWidth < tooltip.offsetWidth * 1.5)
+          tooltip.style.maxWidth = window.innerWidth / 2;
+        else
+          tooltip.style.maxWidth = 340;
+
+        let pos_left = getOffset(target).left + (target.offsetWidth / 2) - (tooltip.offsetWidth / 2);
+        let pos_top  = getOffset(target).top - tooltip.offsetHeight - 10;
+
+        if (pos_left < 0) {
+          pos_left = getOffset(target).left + target.offsetWidth / 2 - 20;
+          tooltip.classList.add("left");
+        }
+        else
+          tooltip.classList.remove("left");
+
+        if (pos_left + tooltip.offsetWidth > window.innerWidth) {
+          pos_left = getOffset(target).left - tooltip.offsetWidth + target.offsetWidth / 2 + 20;
+          tooltip.classList.add("right");
+        }
+        else
+          tooltip.classList.remove("right");
+
+        if (pos_top < 0) {
+          pos_top  = getOffset(target).top + target.offsetHeight + 15;
+          tooltip.classList.add("top");
+        }
+        else
+          tooltip.classList.remove("top");
+        // adding "px" is very important
+        tooltip.style.left = pos_left + "px";
+        tooltip.style.top = pos_top + "px";
+        tooltip.style.opacity  = 1;
+      };
+
+      init_tooltip();
+      window.addEventListener("resize", init_tooltip);
+
+      const remove_tooltip = () => {
+        tooltip.style.opacity  = 0;
+        document.querySelector("#tooltip") && document.body.removeChild(document.querySelector("#tooltip"));
+        target.setAttribute("title", tip );
+      };
+
+      target.addEventListener("mouseleave", remove_tooltip );
+      tooltip.addEventListener("click", remove_tooltip );
+    });
+  }); // forEach ends
+}

--- a/src/utils/bindTooltip.js
+++ b/src/utils/bindTooltip.js
@@ -50,8 +50,8 @@ export default function bindTooltip() {
             tooltip.classList.remove('top');
           }
 
-          tooltip.style.left = posLeft.toString() + 'px';
-          tooltip.style.top = posTop.toString() + 'px';
+          tooltip.style.left = `${posLeft}px`;
+          tooltip.style.top = `${posTop}px`;
           tooltip.style.opacity = 1;
         };
 

--- a/src/utils/bindTooltip.js
+++ b/src/utils/bindTooltip.js
@@ -2,79 +2,74 @@ import getOffset from './getOffset';
 
 export default function bindTooltip() {
   const targets = document.querySelectorAll('[rel=tooltip]');
-  const title = false;
   let tip = false;
   let tooltip = false;
 
   Array.from(targets).forEach(target => {
     target.addEventListener("mouseenter", () => {
 
-      tip = target.getAttribute("title");
-      tooltip = document.createElement("div");
+      tip = target.getAttribute('title');
+      tooltip = document.createElement('div');
       tooltip.id = 'tooltip';
 
-      if (!tip || tip === '') {
-        return false;
+      if (tip && tip !== '') {
+        target.removeAttribute('title');
+        tooltip.style.opacity = 0;
+        tooltip.innerHTML = tip;
+        document.body.appendChild(tooltip);
+
+        const initTooltip = () => {
+          if (window.innerWidth < tooltip.offsetWidth * 1.5) {
+            tooltip.style.maxWidth = window.innerWidth / 2;
+          } else {
+            tooltip.style.maxWidth = 340;
+          }
+
+          let posLeft = getOffset(target).left + (target.offsetWidth / 2);
+          posLeft -= tooltip.offsetWidth / 2;
+          let posTop = getOffset(target).top - tooltip.offsetHeight - 10;
+
+          if (posLeft < 0) {
+            posLeft = getOffset(target).left + target.offsetWidth / 2 - 20;
+            tooltip.classList.add('left');
+          } else {
+            tooltip.classList.remove('left');
+          }
+
+          if (posLeft + tooltip.offsetWidth > window.innerWidth) {
+            posLeft = getOffset(target).left - tooltip.offsetWidth + target.offsetWidth / 2 + 20;
+            tooltip.classList.add('right');
+          } else {
+            tooltip.classList.remove('right');
+          }
+
+          if (posTop < 0) {
+            posTop = getOffset(target).top + target.offsetHeight + 15;
+            tooltip.classList.add('top');
+          } else {
+            tooltip.classList.remove('top');
+          }
+
+          tooltip.style.left = String(posLeft) + 'px';
+          tooltip.style.top = String(posTop) + 'px';
+          tooltip.style.opacity = 1;
+        };
+
+        initTooltip();
+
+        window.addEventListener('resize', initTooltip);
+
+        const removeTooltip = () => {
+          tooltip.style.opacity = 0;
+          if (document.querySelector('#tooltip')) {
+            document.body.removeChild(document.querySelector('#tooltip'));
+          }
+          target.setAttribute('title', tip);
+        };
+
+        target.addEventListener('mouseleave', removeTooltip);
+        tooltip.addEventListener('click', removeTooltip);
       }
-
-      target.removeAttribute('title');
-      tooltip.style.opacity = 0;
-      tooltip.innerHTML = tip;
-      document.body.appendChild(tooltip);
-
-      const initTooltip = () => {
-        if (window.innerWidth < tooltip.offsetWidth * 1.5) {
-          tooltip.style.maxWidth = window.innerWidth / 2;
-        }
-        else {
-          tooltip.style.maxWidth = 340;
-        }
-
-        let posLeft = getOffset(target).left + (target.offsetWidth / 2);
-        posLeft -= tooltip.offsetWidth / 2;
-        let posTop = getOffset(target).top - tooltip.offsetHeight - 10;
-
-        if (posLeft < 0) {
-          posLeft = getOffset(target).left + target.offsetWidth / 2 - 20;
-          tooltip.classList.add('left');
-        }
-        else {
-          tooltip.classList.remove('left');
-        }
-
-        if (posLeft + tooltip.offsetWidth > window.innerWidth) {
-          posLeft = getOffset(target).left - tooltip.offsetWidth + target.offsetWidth / 2 + 20;
-          tooltip.classList.add('right');
-        }
-        else {
-          tooltip.classList.remove('right');
-        }
-
-        if (posTop < 0) {
-          posTop = getOffset(target).top + target.offsetHeight + 15;
-          tooltip.classList.add('top');
-        }
-        else {
-          tooltip.classList.remove('top');
-        }
-
-        tooltip.style.left = String(posLeft) + 'px';
-        tooltip.style.top = String(posTop) + 'px';
-        tooltip.style.opacity = 1;
-      };
-
-      initTooltip();
-
-      window.addEventListener('resize', init_tooltip);
-
-      const remove_tooltip = () => {
-        tooltip.style.opacity  = 0;
-        document.querySelector('#tooltip') && document.body.removeChild(document.querySelector('#tooltip'));
-        target.setAttribute('title', tip );
-      };
-
-      target.addEventListener('mouseleave', remove_tooltip );
-      tooltip.addEventListener('click', remove_tooltip );
     });
   });
 }

--- a/src/utils/bindTooltip.js
+++ b/src/utils/bindTooltip.js
@@ -1,21 +1,21 @@
 import getOffset from './getOffset';
 
 export default function bindTooltip() {
-  let targets = document.querySelectorAll( '[rel=tooltip]' ),
-  target  = false,
-  tooltip = false,
-  title   = false,
-  tip     = false;
+  let targets = document.querySelectorAll( '[rel=tooltip]' );
+  let target  = false;
+  let tooltip = false;
+  let title   = false;
+  let tip     = false;
 
   Array.from(targets).map( target => {
-    target.addEventListener("mouseenter", function() {
+    target.addEventListener("mouseenter", () => {
 
-      tip     = target.getAttribute("title");
-      tooltip = document.createElement("div");
+      tip        = target.getAttribute("title");
+      tooltip    = document.createElement("div");
       tooltip.id = "tooltip";
 
       if(!tip || tip == "")
-      return false;
+        return false;
 
       target.removeAttribute("title");
       tooltip.style.opacity = 0;
@@ -23,7 +23,6 @@ export default function bindTooltip() {
       document.body.appendChild(tooltip);
 
       const init_tooltip = () => {
-        // set width of tooltip to half of window width
         if (window.innerWidth < tooltip.offsetWidth * 1.5)
           tooltip.style.maxWidth = window.innerWidth / 2;
         else
@@ -52,13 +51,14 @@ export default function bindTooltip() {
         }
         else
           tooltip.classList.remove("top");
-        // adding "px" is very important
+        
         tooltip.style.left = pos_left + "px";
         tooltip.style.top = pos_top + "px";
         tooltip.style.opacity  = 1;
       };
 
       init_tooltip();
+      
       window.addEventListener("resize", init_tooltip);
 
       const remove_tooltip = () => {
@@ -70,5 +70,5 @@ export default function bindTooltip() {
       target.addEventListener("mouseleave", remove_tooltip );
       tooltip.addEventListener("click", remove_tooltip );
     });
-  }); // forEach ends
+  });
 }

--- a/src/utils/getOffset.js
+++ b/src/utils/getOffset.js
@@ -1,13 +1,14 @@
-export default function getOffset(elem) {
-  let offsetLeft = 0, offsetTop = 0;
+export default function getOffset(element) {
+  let elem       = element, 
+      offsetLeft = 0,
+      offsetTop  = 0;
 
   do {
-    if (!isNaN( elem.offsetLeft ))
-    {
+    if (!isNaN(elem.offsetLeft)) {
       offsetLeft += elem.offsetLeft;
       offsetTop += elem.offsetTop;
     }
-  } while (elem = elem.offsetParent);
+  } while ((elem = elem.offsetParent));
 
   return {left: offsetLeft, top: offsetTop};
 }

--- a/src/utils/getOffset.js
+++ b/src/utils/getOffset.js
@@ -1,7 +1,7 @@
 export default function getOffset(element) {
-  let elem       = element;
+  let elem = element;
   let offsetLeft = 0;
-  let offsetTop  = 0;
+  let offsetTop = 0;
 
   do {
     if (!isNaN(elem.offsetLeft)) {

--- a/src/utils/getOffset.js
+++ b/src/utils/getOffset.js
@@ -1,0 +1,13 @@
+export default function getOffset(elem) {
+  let offsetLeft = 0, offsetTop = 0;
+
+  do {
+    if (!isNaN( elem.offsetLeft ))
+    {
+      offsetLeft += elem.offsetLeft;
+      offsetTop += elem.offsetTop;
+    }
+  } while (elem = elem.offsetParent);
+
+  return {left: offsetLeft, top: offsetTop};
+}

--- a/src/utils/getOffset.js
+++ b/src/utils/getOffset.js
@@ -1,14 +1,15 @@
 export default function getOffset(element) {
-  let elem       = element, 
-      offsetLeft = 0,
-      offsetTop  = 0;
+  let elem       = element;
+  let offsetLeft = 0;
+  let offsetTop  = 0;
 
   do {
     if (!isNaN(elem.offsetLeft)) {
       offsetLeft += elem.offsetLeft;
       offsetTop += elem.offsetTop;
     }
-  } while ((elem = elem.offsetParent));
+    elem = elem.offsetParent;
+  } while (elem);
 
   return {left: offsetLeft, top: offsetTop};
 }


### PR DESCRIPTION
This PR aims to remove [issue-496](https://github.com/quran/quran.com-frontend/issues/496).

Tooltip working and code can be seen [here.](http://codepen.io/arshdkhn1/pen/aBBXBq)
Test logs:

```
 karma start

18 11 2016 17:47:27.657:WARN [karma]: No captured browser, open http://localhost:9876/
18 11 2016 17:47:27.690:INFO [karma]: Karma v1.2.0 server started at http://localhost:9876/
18 11 2016 17:47:27.690:INFO [launcher]: Launching browser Chrome with unlimited concurrency
18 11 2016 17:47:27.834:INFO [launcher]: Starting browser Chrome
18 11 2016 17:48:27.835:WARN [launcher]: Chrome have not captured in 60000 ms, killing.
18 11 2016 17:48:29.836:WARN [launcher]: Chrome was not killed in 2000 ms, sending SIGKILL.
18 11 2016 17:48:33.929:INFO [launcher]: Trying to start Chrome again (1/2).
18 11 2016 17:48:39.140:INFO [Chrome 54.0.2840 (Linux 0.0.0)]: Connected on socket /#tn8nSPVEYZBc7cyTAAAA with id 14452692
ERROR: 'Warning: Failed propType: Required prop `surah` was not specified in `Audioplayer`.'
ERROR: 'Warning: Failed propType: Required prop `onLoadAyahs` was not specified in `Audioplayer`.'
ERROR: 'Warning: Failed propType: Required prop `buildOnClient` was not specified in `Audioplayer`.'
ERROR: 'Warning: Failed propType: Required prop `isLoadedOnClient` was not specified in `Audioplayer`.'
ERROR: 'Warning: Failed propType: Required prop `isLoading` was not specified in `Audioplayer`.'
ERROR: 'Warning: Failed propType: Required prop `play` was not specified in `Audioplayer`.'
ERROR: 'Warning: Failed propType: Required prop `pause` was not specified in `Audioplayer`.'
ERROR: 'Warning: Failed propType: Required prop `next` was not specified in `Audioplayer`.'
ERROR: 'Warning: Failed propType: Required prop `previous` was not specified in `Audioplayer`.'
ERROR: 'Warning: Failed propType: Required prop `update` was not specified in `Audioplayer`.'
ERROR: 'Warning: Failed propType: Required prop `shouldScroll` was not specified in `Audioplayer`.'
ERROR: 'Warning: Failed propType: Required prop `toggleScroll` was not specified in `Audioplayer`.'
ERROR: 'Warning: Failed propType: Required prop `surah` was not specified in `RepeatButton`.'
ERROR: 'Warning: Failed propType: Required prop `shouldScroll` was not specified in `ScrollButton`.'
ERROR: 'Warning: Failed propType: Required prop `bookmarked` was not specified in `Ayah`.'
ERROR: 'Warning: Failed propType: Required prop `mediaActions` was not specified in `Ayah`.'
ERROR: 'Warning: Failed propType: Required prop `audioActions` was not specified in `Ayah`.'
Chrome 54.0.2840 (Linux 0.0.0) <Ayah /> "before each" hook FAILED
	TypeError: Cannot read property 'setCurrentWord' of undefined
	    at Ayah.renderText (webpack:///src/components/Ayah/index.js:218:34 <- tests.webpack.js:39528:48)
	    at Ayah.render (webpack:///src/components/Ayah/index.js:387:16 <- tests.webpack.js:39738:16)
	    at ShallowComponentWrapper._renderValidatedComponentWithoutOwnerOrContext (webpack:///~/react/lib/ReactCompositeComponent.js:587:0 <- tests.webpack.js:35253:34)
	    at ShallowComponentWrapper.mountComponent (webpack:///~/react/lib/ReactCompositeComponent.js:220:0 <- tests.webpack.js:34886:30)
	    at ShallowComponentWrapper.wrapper [as mountComponent] (webpack:///~/react/lib/ReactPerf.js:66:0 <- tests.webpack.js:2787:21)
	    at ReactShallowRenderer._render (webpack:///~/react/lib/ReactTestUtils.js:366:0 <- tests.webpack.js:69427:14)
	    at _batchedRender (webpack:///~/react/lib/ReactTestUtils.js:348:0 <- tests.webpack.js:69409:12)
	    at ReactDefaultBatchingStrategyTransaction.perform (webpack:///~/react/lib/Transaction.js:136:0 <- tests.webpack.js:11199:20)
	    at Object.batchedUpdates (webpack:///~/react/lib/ReactDefaultBatchingStrategy.js:62:0 <- tests.webpack.js:35814:19)
	    at Object.batchedUpdates (webpack:///~/react/lib/ReactUpdates.js:94:0 <- tests.webpack.js:2918:20)
Chrome 54.0.2840 (Linux 0.0.0): Executed 30 of 58 (1 FAILED) (0 secs / 0.178 secChrome 54.0.2840 (Linux 0.0.0): Executed 31 of 58 (1 FAILED) (0 secs / 0.178 secChrome 54.0.2840 (Linux 0.0.0): Executed 32 of 58 (1 FAILED) (0 secs / 0.198 secChrome 54.0.2840 (Linux 0.0.0): Executed 33 of 58 (1 FAILED) (0 secs / 0.203 secChrome 54.0.2840 (Linux 0.0.0): Executed 34 of 58 (1 FAILED) (0 secs / 0.205 secChrome 54.0.2840 (Linux 0.0.0): Executed 35 of 58 (1 FAILED) (0 secs / 0.206 secChrome 54.0.2840 (Linux 0.0.0): Executed 36 of 58 (1 FAILED) (0 secs / 0.212 secChrome 54.0.2840 (Linux 0.0.0): Executed 37 of 58 (1 FAILED) (0 secs / 0.212 secChrome 54.0.2840 (Linux 0.0.0) <QuickSurahs /> Should render QuickSurahs component FAILED
	TypeError: Enzyme received a complex CSS selector ('.list-inline li') that it does not currently support
	    at selectorError (webpack:///~/enzyme/build/Utils.js:185:0 <- tests.webpack.js:8003:10)
	    at buildPredicate (webpack:///~/enzyme/build/ShallowTraversal.js:137:0 <- tests.webpack.js:26035:40)
	    at ShallowWrapper.find (webpack:///~/enzyme/build/ShallowWrapper.js:319:0 <- tests.webpack.js:26430:62)
	    at context.<anonymous> (webpack:///src/components/Home/QuickSurahs/spec.js:11:21 <- tests.webpack.js:21955:22)
Chrome 54.0.2840 (Linux 0.0.0): Executed 38 of 58 (2 FAILED) (0 secs / 0.219 secChrome 54.0.2840 (Linux 0.0.0) <QuickSurahs /> Should render QuickSurahs component with Surah Al-Kahf FAILED
	TypeError: Enzyme received a complex CSS selector ('.list-inline li') that it does not currently support
	    at selectorError (webpack:///~/enzyme/build/Utils.js:185:0 <- tests.webpack.js:8003:10)
	    at buildPredicate (webpack:///~/enzyme/build/ShallowTraversal.js:137:0 <- tests.webpack.js:26035:40)
	    at ShallowWrapper.find (webpack:///~/enzyme/build/ShallowWrapper.js:319:0 <- tests.webpack.js:26430:62)
	    at context.<anonymous> (webpack:///src/components/Home/QuickSurahs/spec.js:18:21 <- tests.webpack.js:21962:22)
Chrome 54.0.2840 (Linux 0.0.0): Executed 39 of 58 (3 FAILED) (0 secs / 0.223 secChrome 54.0.2840 (Linux 0.0.0) <SurahsList /> Should render SurahList component FAILED
	TypeError: Enzyme received a complex CSS selector ('.col-md-4 li') that it does not currently support
	    at selectorError (webpack:///~/enzyme/build/Utils.js:185:0 <- tests.webpack.js:8003:10)
	    at buildPredicate (webpack:///~/enzyme/build/ShallowTraversal.js:137:0 <- tests.webpack.js:26035:40)
	    at ShallowWrapper.find (webpack:///~/enzyme/build/ShallowWrapper.js:319:0 <- tests.webpack.js:26430:62)
	    at context.<anonymous> (webpack:///src/components/Home/SurahsList/spec.js:12:21 <- tests.webpack.js:21994:22)
Chrome 54.0.2840 (Linux 0.0.0): Executed 40 of 58 (4 FAILED) (0 secs / 0.225 secChrome 54.0.2840 (Linux 0.0.0): Executed 41 of 58 (4 FAILED) (0 secs / 0.225 secChrome 54.0.2840 (Linux 0.0.0): Executed 42 of 58 (4 FAILED) (0 secs / 0.225 secChrome 54.0.2840 (Linux 0.0.0): Executed 43 of 58 (4 FAILED) (0 secs / 0.227 secChrome 54.0.2840 (Linux 0.0.0): Executed 44 of 58 (4 FAILED) (0 secs / 0.229 secChrome 54.0.2840 (Linux 0.0.0): Executed 45 of 58 (4 FAILED) (0 secs / 0.231 secChrome 54.0.2840 (Linux 0.0.0): Executed 46 of 58 (4 FAILED) (0 secs / 0.232 secChrome 54.0.2840 (Linux 0.0.0): Executed 47 of 58 (4 FAILED) (0 secs / 0.232 secChrome 54.0.2840 (Linux 0.0.0): Executed 48 of 58 (4 FAILED) (0 secs / 0.234 secERROR: 'Warning: Failed propType: Required prop `surah` was not specified in `TopOptions`.'
Chrome 54.0.2840 (Linux 0.0.0): Executed 48 of 58 (4 FAILED) (0 secs / 0.234 secERROR: 'Warning: Failed propType: Required prop `surah` was not specified in `Title`. Check the render method of `TopOptions`.'
Chrome 54.0.2840 (Linux 0.0.0): Executed 48 of 58 (4 FAILED) (0 secs / 0.234 secERROR: 'Warning: Failed propType: Required prop `surah` was not specified in `Share`. Check the render method of `TopOptions`.'
Chrome 54.0.2840 (Linux 0.0.0): Executed 48 of 58 (4 FAILED) (0 secs / 0.234 secChrome 54.0.2840 (Linux 0.0.0): Executed 49 of 58 (4 FAILED) (0 secs / 0.244 secChrome 54.0.2840 (Linux 0.0.0): Executed 50 of 58 (4 FAILED) (0 secs / 0.246 secChrome 54.0.2840 (Linux 0.0.0) <Title /> should not show previous surah if on the first surah FAILED
	AssertionError: expected 0 to equal 1
	    at context.<anonymous> (webpack:///src/containers/Surah/Title/spec.js:34:20 <- tests.webpack.js:22747:21)
Chrome 54.0.2840 (Linux 0.0.0): Executed 51 of 58 (5 FAILED) (0 secs / 0.248 secChrome 54.0.2840 (Linux 0.0.0) <Title /> should not show next surah if on the last surah FAILED
	AssertionError: expected 0 to equal 1
	    at context.<anonymous> (webpack:///src/containers/Surah/Title/spec.js:44:24 <- tests.webpack.js:22757:25)
Chrome 54.0.2840 (Linux 0.0.0): Executed 52 of 58 (6 FAILED) (0 secs / 0.248 secChrome 54.0.2840 (Linux 0.0.0) <Title /> should show both next and previous if surah is neither last or first FAILED
	AssertionError: expected 0 to equal 1
	    at context.<anonymous> (webpack:///src/containers/Surah/Title/spec.js:55:24 <- tests.webpack.js:22768:25)
Chrome 54.0.2840 (Linux 0.0.0): Executed 53 of 58 (7 FAILED) (0 secs / 0.248 secChrome 54.0.2840 (Linux 0.0.0): Executed 54 of 58 (7 FAILED) (0 secs / 0.249 secChrome 54.0.2840 (Linux 0.0.0): Executed 55 of 58 (7 FAILED) (0 secs / 0.25 secsChrome 54.0.2840 (Linux 0.0.0): Executed 56 of 58 (7 FAILED) (0 secs / 0.25 secsChrome 54.0.2840 (Linux 0.0.0): Executed 56 of 58 (7 FAILED) (0.65 secs / 0.25 secs)
18 11 2016 17:49:28.632:WARN [Chrome 54.0.2840 (Linux 0.0.0)]: Disconnected (1 tChrome 54.0.2840 (Linux 0.0.0) ERROR
  Disconnectedundefined
Chrome 54.0.2840 (Linux 0.0.0): Executed 56 of 58 (7 FAILED) (0.65 secs / 0.25 secs)
18 11 2016 17:49:29.022:ERROR [launcher]: Chrome crashed.
	
18 11 2016 17:49:29.073:INFO [launcher]: Trying to start Chrome again (2/2).
18 11 2016 17:49:31.126:INFO [Chrome 54.0.2840 (Linux 0.0.0)]: Connected on socket /#4QZtVNVYf8JZnm9dAAAB with id 14452692
ERROR: 'Warning: Failed propType: Required prop `surah` was not specified in `Audioplayer`.'
ERROR: 'Warning: Failed propType: Required prop `onLoadAyahs` was not specified in `Audioplayer`.'
ERROR: 'Warning: Failed propType: Required prop `buildOnClient` was not specified in `Audioplayer`.'
ERROR: 'Warning: Failed propType: Required prop `isLoadedOnClient` was not specified in `Audioplayer`.'
ERROR: 'Warning: Failed propType: Required prop `isLoading` was not specified in `Audioplayer`.'
ERROR: 'Warning: Failed propType: Required prop `play` was not specified in `Audioplayer`.'
ERROR: 'Warning: Failed propType: Required prop `pause` was not specified in `Audioplayer`.'
ERROR: 'Warning: Failed propType: Required prop `next` was not specified in `Audioplayer`.'
ERROR: 'Warning: Failed propType: Required prop `previous` was not specified in `Audioplayer`.'
ERROR: 'Warning: Failed propType: Required prop `update` was not specified in `Audioplayer`.'
ERROR: 'Warning: Failed propType: Required prop `shouldScroll` was not specified in `Audioplayer`.'
ERROR: 'Warning: Failed propType: Required prop `toggleScroll` was not specified in `Audioplayer`.'
ERROR: 'Warning: Failed propType: Required prop `surah` was not specified in `RepeatButton`.'
ERROR: 'Warning: Failed propType: Required prop `shouldScroll` was not specified in `ScrollButton`.'
ERROR: 'Warning: Failed propType: Required prop `bookmarked` was not specified in `Ayah`.'
ERROR: 'Warning: Failed propType: Required prop `mediaActions` was not specified in `Ayah`.'
ERROR: 'Warning: Failed propType: Required prop `audioActions` was not specified in `Ayah`.'
Chrome 54.0.2840 (Linux 0.0.0) <Ayah /> "before each" hook FAILED
	TypeError: Cannot read property 'setCurrentWord' of undefined
	    at Ayah.renderText (webpack:///src/components/Ayah/index.js:218:34 <- tests.webpack.js:39528:48)
	    at Ayah.render (webpack:///src/components/Ayah/index.js:387:16 <- tests.webpack.js:39738:16)
	    at ShallowComponentWrapper._renderValidatedComponentWithoutOwnerOrContext (webpack:///~/react/lib/ReactCompositeComponent.js:587:0 <- tests.webpack.js:35253:34)
	    at ShallowComponentWrapper.mountComponent (webpack:///~/react/lib/ReactCompositeComponent.js:220:0 <- tests.webpack.js:34886:30)
	    at ShallowComponentWrapper.wrapper [as mountComponent] (webpack:///~/react/lib/ReactPerf.js:66:0 <- tests.webpack.js:2787:21)
	    at ReactShallowRenderer._render (webpack:///~/react/lib/ReactTestUtils.js:366:0 <- tests.webpack.js:69427:14)
	    at _batchedRender (webpack:///~/react/lib/ReactTestUtils.js:348:0 <- tests.webpack.js:69409:12)
	    at ReactDefaultBatchingStrategyTransaction.perform (webpack:///~/react/lib/Transaction.js:136:0 <- tests.webpack.js:11199:20)
	    at Object.batchedUpdates (webpack:///~/react/lib/ReactDefaultBatchingStrategy.js:62:0 <- tests.webpack.js:35814:19)
	    at Object.batchedUpdates (webpack:///~/react/lib/ReactUpdates.js:94:0 <- tests.webpack.js:2918:20)
Chrome 54.0.2840 (Linux 0.0.0): Executed 30 of 58 (1 FAILED) (0 secs / 0.129 secChrome 54.0.2840 (Linux 0.0.0): Executed 31 of 58 (1 FAILED) (0 secs / 0.129 secChrome 54.0.2840 (Linux 0.0.0): Executed 32 of 58 (1 FAILED) (0 secs / 0.161 secChrome 54.0.2840 (Linux 0.0.0): Executed 33 of 58 (1 FAILED) (0 secs / 0.167 secChrome 54.0.2840 (Linux 0.0.0): Executed 34 of 58 (1 FAILED) (0 secs / 0.17 secsChrome 54.0.2840 (Linux 0.0.0): Executed 35 of 58 (1 FAILED) (0 secs / 0.171 secChrome 54.0.2840 (Linux 0.0.0): Executed 36 of 58 (1 FAILED) (0 secs / 0.177 secChrome 54.0.2840 (Linux 0.0.0): Executed 37 of 58 (1 FAILED) (0 secs / 0.177 secChrome 54.0.2840 (Linux 0.0.0) <QuickSurahs /> Should render QuickSurahs component FAILED
	TypeError: Enzyme received a complex CSS selector ('.list-inline li') that it does not currently support
	    at selectorError (webpack:///~/enzyme/build/Utils.js:185:0 <- tests.webpack.js:8003:10)
	    at buildPredicate (webpack:///~/enzyme/build/ShallowTraversal.js:137:0 <- tests.webpack.js:26035:40)
	    at ShallowWrapper.find (webpack:///~/enzyme/build/ShallowWrapper.js:319:0 <- tests.webpack.js:26430:62)
	    at context.<anonymous> (webpack:///src/components/Home/QuickSurahs/spec.js:11:21 <- tests.webpack.js:21955:22)
Chrome 54.0.2840 (Linux 0.0.0): Executed 38 of 58 (2 FAILED) (0 secs / 0.179 secChrome 54.0.2840 (Linux 0.0.0) <QuickSurahs /> Should render QuickSurahs component with Surah Al-Kahf FAILED
	TypeError: Enzyme received a complex CSS selector ('.list-inline li') that it does not currently support
	    at selectorError (webpack:///~/enzyme/build/Utils.js:185:0 <- tests.webpack.js:8003:10)
	    at buildPredicate (webpack:///~/enzyme/build/ShallowTraversal.js:137:0 <- tests.webpack.js:26035:40)
	    at ShallowWrapper.find (webpack:///~/enzyme/build/ShallowWrapper.js:319:0 <- tests.webpack.js:26430:62)
	    at context.<anonymous> (webpack:///src/components/Home/QuickSurahs/spec.js:18:21 <- tests.webpack.js:21962:22)
Chrome 54.0.2840 (Linux 0.0.0): Executed 39 of 58 (3 FAILED) (0 secs / 0.181 secChrome 54.0.2840 (Linux 0.0.0) <SurahsList /> Should render SurahList component FAILED
	TypeError: Enzyme received a complex CSS selector ('.col-md-4 li') that it does not currently support
	    at selectorError (webpack:///~/enzyme/build/Utils.js:185:0 <- tests.webpack.js:8003:10)
	    at buildPredicate (webpack:///~/enzyme/build/ShallowTraversal.js:137:0 <- tests.webpack.js:26035:40)
	    at ShallowWrapper.find (webpack:///~/enzyme/build/ShallowWrapper.js:319:0 <- tests.webpack.js:26430:62)
	    at context.<anonymous> (webpack:///src/components/Home/SurahsList/spec.js:12:21 <- tests.webpack.js:21994:22)
Chrome 54.0.2840 (Linux 0.0.0): Executed 40 of 58 (4 FAILED) (0 secs / 0.182 secChrome 54.0.2840 (Linux 0.0.0): Executed 41 of 58 (4 FAILED) (0 secs / 0.182 secChrome 54.0.2840 (Linux 0.0.0): Executed 42 of 58 (4 FAILED) (0 secs / 0.182 secChrome 54.0.2840 (Linux 0.0.0): Executed 43 of 58 (4 FAILED) (0 secs / 0.183 secChrome 54.0.2840 (Linux 0.0.0): Executed 44 of 58 (4 FAILED) (0 secs / 0.184 secChrome 54.0.2840 (Linux 0.0.0): Executed 45 of 58 (4 FAILED) (0 secs / 0.185 secChrome 54.0.2840 (Linux 0.0.0): Executed 46 of 58 (4 FAILED) (0 secs / 0.186 secChrome 54.0.2840 (Linux 0.0.0): Executed 47 of 58 (4 FAILED) (0 secs / 0.186 secChrome 54.0.2840 (Linux 0.0.0): Executed 48 of 58 (4 FAILED) (0 secs / 0.188 secERROR: 'Warning: Failed propType: Required prop `surah` was not specified in `TopOptions`.'
Chrome 54.0.2840 (Linux 0.0.0): Executed 48 of 58 (4 FAILED) (0 secs / 0.188 secERROR: 'Warning: Failed propType: Required prop `surah` was not specified in `Title`. Check the render method of `TopOptions`.'
Chrome 54.0.2840 (Linux 0.0.0): Executed 48 of 58 (4 FAILED) (0 secs / 0.188 secERROR: 'Warning: Failed propType: Required prop `surah` was not specified in `Share`. Check the render method of `TopOptions`.'
Chrome 54.0.2840 (Linux 0.0.0): Executed 48 of 58 (4 FAILED) (0 secs / 0.188 secChrome 54.0.2840 (Linux 0.0.0): Executed 49 of 58 (4 FAILED) (0 secs / 0.19 secsChrome 54.0.2840 (Linux 0.0.0): Executed 50 of 58 (4 FAILED) (0 secs / 0.191 secChrome 54.0.2840 (Linux 0.0.0) <Title /> should not show previous surah if on the first surah FAILED
	AssertionError: expected 0 to equal 1
	    at context.<anonymous> (webpack:///src/containers/Surah/Title/spec.js:34:20 <- tests.webpack.js:22747:21)
Chrome 54.0.2840 (Linux 0.0.0): Executed 51 of 58 (5 FAILED) (0 secs / 0.192 secChrome 54.0.2840 (Linux 0.0.0) <Title /> should not show next surah if on the last surah FAILED
	AssertionError: expected 0 to equal 1
	    at context.<anonymous> (webpack:///src/containers/Surah/Title/spec.js:44:24 <- tests.webpack.js:22757:25)
Chrome 54.0.2840 (Linux 0.0.0): Executed 52 of 58 (6 FAILED) (0 secs / 0.192 secChrome 54.0.2840 (Linux 0.0.0) <Title /> should show both next and previous if surah is neither last or first FAILED
	AssertionError: expected 0 to equal 1
	    at context.<anonymous> (webpack:///src/containers/Surah/Title/spec.js:55:24 <- tests.webpack.js:22768:25)
Chrome 54.0.2840 (Linux 0.0.0): Executed 53 of 58 (7 FAILED) (0 secs / 0.193 secChrome 54.0.2840 (Linux 0.0.0): Executed 54 of 58 (7 FAILED) (0 secs / 0.193 secChrome 54.0.2840 (Linux 0.0.0): Executed 55 of 58 (7 FAILED) (0 secs / 0.194 secChrome 54.0.2840 (Linux 0.0.0): Executed 56 of 58 (7 FAILED) (0 secs / 0.194 secChrome 54.0.2840 (Linux 0.0.0): Executed 56 of 58 (7 FAILED) (0.381 secs / 0.194 secs)

```