### PR TITLE
Fix node-http-proxy host in proxy request

### DIFF
--- a/src/server/config/express.js
+++ b/src/server/config/express.js
@@ -20,7 +20,9 @@ const proxyApi = httpProxy.createProxyServer({
 const proxyOneQuran = httpProxy.createProxyServer({
   target: process.env.ONE_QURAN_URL,
   secure: false,
-  proxyTimeout: 15000
+  proxyTimeout: 15000,
+  autoRewrite: true,
+  changeOrigin: true
 });
 
 proxyApi.on('error', (error, req, res) => {


### PR DESCRIPTION
node-http-proxy was putting a host header with the current server name,
which was thus causing nginx on the receiving end to send the request to
the default handler (or the first one). This patch asks node-http-proxy
to rewrite the host and port, and also to change the origin of the host
header to onequran's url.