### PR TITLE
Fix loading always shows when reaching the end of the surah

### DIFF
--- a/src/containers/Surah/index.js
+++ b/src/containers/Surah/index.js
@@ -475,7 +475,9 @@ function mapStateToProps(state, ownProps) {
   const surahId = parseInt(ownProps.params.surahId, 10);
   const surah: Object = state.surahs.entities[surahId];
   const ayahs: Object = state.ayahs.entities[surahId];
-  const ayahIds = new Set(Object.keys(ayahs).map(key => parseInt(key.split(':')[1], 10)));
+  const ayahArray = Object.keys(ayahs).map(key => parseInt(key.split(':')[1], 10));
+  const ayahIds = new Set(ayahArray);
+  const lastAyahInArray = ayahArray.slice(-1)[0];
 
   return {
     surah,
@@ -486,7 +488,7 @@ function mapStateToProps(state, ownProps) {
     currentAyah: state.audioplayer.currentAyah,
     isAuthenticated: state.auth.loaded,
     currentWord: state.ayahs.currentWord,
-    isEndOfSurah: ayahIds.size === surah.ayat,
+    isEndOfSurah: lastAyahInArray === surah.ayat,
     surahs: state.surahs.entities,
     bookmarks: state.bookmarks.entities,
     isLoading: state.ayahs.loading,


### PR DESCRIPTION
This should resolve https://github.com/quran/quran.com-frontend/issues/485

### Issue
The issue is because it compares `ayahIds.size` with `surah.ayat`.
`Ayahids` is a subset of all ayah, in this case the size is 7 and total ayah in An-nisa is 176 so `Loading` is always displayed.

### How to fix
Fixing it by comparing the last ayah in array with `surah.ayat`

### How to test 
Head to surah An-Nisa quran.com/4/170 and see if loading is still displayed