### PR TITLE
Fixes for repeat range bugs

### DIFF
--- a/src/components/Audioplayer/RepeatDropdown/index.js
+++ b/src/components/Audioplayer/RepeatDropdown/index.js
@@ -72,11 +72,15 @@ class RepeatButton extends Component {
             <FormControl
               componentClass="select"
               value={repeat.from}
-              onChange={event => setRepeat({
-                ...repeat,
-                from: parseInt(event.target.value, 10),
-                to: parseInt(event.target.value, 10) + 3
-              })}
+              onChange={(event) => {
+                let to = parseInt(event.target.value, 10) + 3;
+                to = to < surah.ayat ? to : surah.ayat;
+                setRepeat({
+                  ...repeat,
+                  from: parseInt(event.target.value, 10),
+                  to
+                });
+              }}
             >
               {
                 array.map((ayah, index) => (

--- a/src/components/Audioplayer/RepeatDropdown/index.js
+++ b/src/components/Audioplayer/RepeatDropdown/index.js
@@ -83,11 +83,16 @@ class RepeatButton extends Component {
               }}
             >
               {
-                array.map((ayah, index) => (
-                  <option key={index} value={index + 1}>
-                    {index + 1}
-                  </option>
-                ))
+                array.reduce((options, ayah, index) => {
+                  if (index + 1 < surah.ayat) { // Exclude last verse
+                    options.push(
+                      <option key={index} value={index + 1}>
+                        {index + 1}
+                      </option>
+                    );
+                  }
+                  return options;
+                }, [])
               }
             </FormControl>
           </li>

--- a/src/components/Audioplayer/RepeatDropdown/index.js
+++ b/src/components/Audioplayer/RepeatDropdown/index.js
@@ -104,11 +104,16 @@ class RepeatButton extends Component {
               onChange={event => setRepeat({ ...repeat, to: parseInt(event.target.value, 10) })}
             >
               {
-                array.map((ayah, index) => (
-                  <option key={index} value={repeat.from ? index + 1 + repeat.from : index + 1}>
-                    {repeat.from ? index + 1 + repeat.from : index + 1}
-                  </option>
-                ))
+                array.reduce((options, ayah, index) => {
+                  if ((repeat.from ? repeat.from : 1) < index + 1 && index + 1 <= surah.ayat) {
+                    options.push(
+                      <option key={index} value={index + 1}>
+                        {index + 1}
+                      </option>
+                    );
+                  }
+                  return options;
+                }, [])
               }
             </FormControl>
           </li>


### PR DESCRIPTION
These are fixes for a few bugs in the audio player range component.

* When the user selects a verse in the _from_ component, _to_ is set to _from_'s value + 3. This leads to _to_ going beyond the last verse if the last verse is selected as _from_.

* When the user selects a verse in _from_, the _to_ options are incorrectly calculated beyond the number of verses in the surah.

Assumptions:
- The props.surah.ayat number is 1 or more. 
- A surah with 10 verses will have surah.ayat == 10.
- From should not have an option where the option's value == surah.ayat.
- To should not have an option where the option's value == 1.

I wanted to add a test for this but I didn't see an example where a similar sort was done. I also wanted to run the current tests but I couldn't get them working. 