### PR TITLE
Fix/smart banner appid switch

### DIFF
--- a/src/components/SmartBanner/index.js
+++ b/src/components/SmartBanner/index.js
@@ -101,11 +101,11 @@ class SmartBanner extends Component {
     return /app-id=([^\s,]+)/.exec(meta.getAttribute('content'))[1];
   }
 
-  hide() {
+  hide = () => {
     window.document.querySelector('html').classList.remove('smartbanner-show');
   }
 
-  show() {
+  show = () => {
     window.document.querySelector('html').classList.add('smartbanner-show');
   }
 

--- a/src/components/SmartBanner/index.js
+++ b/src/components/SmartBanner/index.js
@@ -76,13 +76,13 @@ class SmartBanner extends Component {
     const mixins = {
       ios: {
         icon: 'app-banner-ios.jpg',
-        appMeta: 'google-play-app',
+        appMeta: 'apple-itunes-app',
         getStoreLink: () =>
           `https://itunes.apple.com/${this.props.appStoreLanguage}/app/id`,
       },
       android: {
         icon: 'app-banner-android.png',
-        appMeta: 'apple-itunes-app',
+        appMeta: 'google-play-app',
         getStoreLink: () =>
           'http://play.google.com/store/apps/details?id=',
       }

--- a/src/components/SmartBanner/index.js
+++ b/src/components/SmartBanner/index.js
@@ -101,11 +101,11 @@ class SmartBanner extends Component {
     return /app-id=([^\s,]+)/.exec(meta.getAttribute('content'))[1];
   }
 
-  hide = () => {
+  hide() {
     window.document.querySelector('html').classList.remove('smartbanner-show');
   }
 
-  show = () => {
+  show() {
     window.document.querySelector('html').classList.add('smartbanner-show');
   }
 
@@ -178,7 +178,7 @@ class SmartBanner extends Component {
           <a
             tabIndex="-1"
             className="smartbanner-close"
-            onClick={this.close}
+            onClick={() => this.close()}
             data-metrics-event-name="SmartBanner:close"
           >
             <i className="fa fa-times-circle" />
@@ -190,7 +190,7 @@ class SmartBanner extends Component {
             <span>{inStore}</span>
           </div>
 
-          <a href={link} onClick={this.install} className="smartbanner-button" data-metrics-event-name="SmartBanner:InstallAapp">
+          <a href={link} onClick={() => this.install()} className="smartbanner-button" data-metrics-event-name="SmartBanner:InstallAapp">
             <span className="smartbanner-button-text">{this.props.button}</span>
           </a>
         </div>


### PR DESCRIPTION
This is in regards to issue #604. After some testing, I realised the meta names were the other way around.