### PR TITLE
Fixes #659 Double Click for Word Audio

### DIFF
--- a/src/components/Word/index.js
+++ b/src/components/Word/index.js
@@ -28,6 +28,13 @@ export default class Word extends React.Component {
     return title;
   }
 
+  handleWordDoubleClick = () => {
+    const { word } = this.props;
+    const audio = new Audio(word.audio.url); // eslint-disable-line
+
+    audio.play();
+  }
+
   handleWordClick = () => {
     const { word, currentVerse, audioActions, audioPosition, isPlaying, isSearched } = this.props;
 
@@ -61,6 +68,7 @@ export default class Word extends React.Component {
         key={word.code}
         id={id}
         onClick={this.handleWordClick}
+        onDoubleClick={this.handleWordDoubleClick}
         className={`${className} pointer`}
         title={this.buildTooltip(word, tooltip)}
         dangerouslySetInnerHTML={{ __html: word.code }}

--- a/src/components/Word/index.js
+++ b/src/components/Word/index.js
@@ -28,14 +28,14 @@ export default class Word extends React.Component {
     return title;
   }
 
-  handleWordDoubleClick = () => {
+  handleWordPlay = () => {
     const { word } = this.props;
     const audio = new Audio(word.audio.url); // eslint-disable-line
 
     audio.play();
   }
 
-  handleWordClick = () => {
+  handleSegmentPlay = () => {
     const { word, currentVerse, audioActions, audioPosition, isPlaying, isSearched } = this.props;
 
     if (isSearched) {
@@ -67,8 +67,8 @@ export default class Word extends React.Component {
         { ...bindTooltip}
         key={word.code}
         id={id}
-        onClick={this.handleWordClick}
-        onDoubleClick={this.handleWordDoubleClick}
+        onDoubleClick={this.handleSegmentPlay}
+        onClick={this.handleWordPlay}
         className={`${className} pointer`}
         title={this.buildTooltip(word, tooltip)}
         dangerouslySetInnerHTML={{ __html: word.code }}

--- a/src/types/wordType.js
+++ b/src/types/wordType.js
@@ -9,7 +9,6 @@ export default PropTypes.shape({
   lineNumber: PropTypes.number.isRequired,
   pageNumber: PropTypes.number.isRequired,
   position: PropTypes.number.isRequired,
-  resourceId: PropTypes.number.isRequired,
   translation: PropTypes.shape({
     languageName: PropTypes.string,
     text: PropTypes.string


### PR DESCRIPTION
Double click does not work on mobile. We already have `onClick` for segments. Thoughts? 

I think we should remove the click for segments and just use the word audio