### PR TITLE
Fix autoscroll jankiness

### DIFF
--- a/src/components/Audioplayer/index.js
+++ b/src/components/Audioplayer/index.js
@@ -141,11 +141,12 @@ export class Audioplayer extends Component {
 
     if (isPlaying) pause();
 
-    if (!this[camelize(`get_${direction}`)]()) return pause();
+    const nextVerse = this[camelize(`get_${direction}`)]();
+    if (!nextVerse) return pause();
 
     this.props[direction](currentVerse);
 
-    this.handleScrollTo(currentVerse);
+    this.handleScrollTo(nextVerse);
 
     this.preloadNext();
 
@@ -154,11 +155,15 @@ export class Audioplayer extends Component {
     return false;
   }
 
-  handleScrollTo = (ayahNum = this.props.currentVerse) => {
+  scrollToVerse = (ayahNum = this.props.currentVerse) => {
+    scroller.scrollTo(`verse:${ayahNum}`, -45);
+  }
+
+  handleScrollTo = (ayahNum) => {
     const { shouldScroll } = this.props;
 
     if (shouldScroll) {
-      scroller.scrollTo(`ayah:${ayahNum}`, -150);
+      this.scrollToVerse(ayahNum);
     }
   }
 
@@ -250,12 +255,7 @@ export class Audioplayer extends Component {
     const { shouldScroll, currentVerse } = this.props;
 
     if (!shouldScroll) { // we use the inverse (!) here because we're toggling, so false is true
-      const elem = document.getElementsByName(`ayah:${currentVerse}`)[0];
-      if (elem && elem.getBoundingClientRect().top < 0) { // if the ayah is above our scroll offset
-        scroller.scrollTo(`ayah:${currentVerse}`, -150);
-      } else {
-        scroller.scrollTo(`ayah:${currentVerse}`, -80);
-      }
+      this.scrollToVerse(currentVerse);
     }
 
     this.props.toggleScroll();

--- a/src/redux/schemas.js
+++ b/src/redux/schemas.js
@@ -1,7 +1,7 @@
 import { schema } from 'normalizr';
 
 export const chaptersSchema = new schema.Entity('chapters', {}, { idAttribute: 'id' });
-export const versesSchema = new schema.Entity('verses', {}, { idAttribute: 'id' });
+export const versesSchema = new schema.Entity('verses', {}, { idAttribute: 'verseKey' });
 export const bookmarksSchema = new schema.Entity('bookmarks', {}, { idAttribute: 'verseKey' });
 
 const schemas = {

--- a/src/utils/scroller.js
+++ b/src/utils/scroller.js
@@ -10,8 +10,17 @@ export default {
 
     const nodeRect = node.getBoundingClientRect();
     const bodyRect = document.body.getBoundingClientRect();
-    const scrollOffset = nodeRect.top - bodyRect.top;
+    const scrollOffset = (nodeRect.top - bodyRect.top) + offset;
+    const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
+    const viewportHeight = Math.max(document.documentElement.clientHeight, window.innerHeight || 0);
 
-    window.scrollTo(0, scrollOffset + offset);
+
+    // Only scroll if item is not already on screen.
+    // If an item is larger than the screen, don't scroll to the top of it if it's already filling
+    // the screen.
+    if ((scrollOffset < scrollTop) !==
+        (scrollOffset + nodeRect.height > scrollTop + viewportHeight)) {
+      window.scrollTo(0, scrollOffset);
+    }
   }
 };

--- a/src/utils/scroller.js
+++ b/src/utils/scroller.js
@@ -19,7 +19,7 @@ export default {
     // If an item is larger than the screen, don't scroll to the top of it if it's already filling
     // the screen.
     if ((scrollOffset < scrollTop) !==
-        (scrollOffset + nodeRect.height > scrollTop + viewportHeight)) {
+        (scrollOffset + nodeRect.height > scrollTop + viewportHeight + offset)) {
       window.scrollTo(0, scrollOffset);
     }
   }


### PR DESCRIPTION
This fixes #637, where scrolling lags 1 verse behind the player's current position. It also fixes the scroll alignment, and handles cases where the verse is already fully visible, or too big to fit on the screen.

A v3 API change caused ayah object keys to be just the ayah number, instead of `surah:ayah`. I don't know if the change was intentional, but it broke a lot of stuff (most notably, the audio player).