### PR TITLE
Render less until client

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "react-hot-loader": "3.0.0-beta.6",
     "react-inlinesvg": "0.5.4",
     "react-intl": "2.1.5",
-    "react-loadable": "^3.0.1",
+    "react-loadable": "^3.3.1",
     "react-metrics": "1.2.1",
     "react-paginate": "4.1.0",
     "react-redux": "5.0.1",

--- a/src/containers/App/index.js
+++ b/src/containers/App/index.js
@@ -96,44 +96,44 @@ class App extends Component {
         {children || main}
         <SmartBanner title="The Noble Quran - القرآن الكريم" button="Install" />
         <Footer />
-
-        <Modal
-          bsSize="large"
-          show={media && media.content}
-          onHide={removeMedia}
-        >
-          <ModalHeader closeButton>
-            <ModalTitle className="montserrat">
-              {media.content && media.content.authorName}
-            </ModalTitle>
-          </ModalHeader>
-          <ModalBody>
-            <div
-              className="embed-responsive embed-responsive-16by9"
-              dangerouslySetInnerHTML={{
-                __html: media.content && media.content.embedText
-              }}
-            />
-          </ModalBody>
-        </Modal>
-
-        <Modal
-          bsSize="large"
-          show={!!footNote || loadingFootNote}
-          onHide={removeFootNote}
-        >
-          <ModalHeader closeButton>
-            <ModalTitle className="montserrat">
-              Foot note
-            </ModalTitle>
-          </ModalHeader>
-          <ModalBody>
-            <div
-              className={`${footNote && footNote.languageName}`}
-              dangerouslySetInnerHTML={{ __html: footNoteText }}
-            />
-          </ModalBody>
-        </Modal>
+        {__CLIENT__ &&
+          <Modal
+            bsSize="large"
+            show={media && media.content}
+            onHide={removeMedia}
+          >
+            <ModalHeader closeButton>
+              <ModalTitle className="montserrat">
+                {media.content && media.content.authorName}
+              </ModalTitle>
+            </ModalHeader>
+            <ModalBody>
+              <div
+                className="embed-responsive embed-responsive-16by9"
+                dangerouslySetInnerHTML={{
+                  __html: media.content && media.content.embedText
+                }}
+              />
+            </ModalBody>
+          </Modal>}
+        {__CLIENT__ &&
+          <Modal
+            bsSize="large"
+            show={!!footNote || loadingFootNote}
+            onHide={removeFootNote}
+          >
+            <ModalHeader closeButton>
+              <ModalTitle className="montserrat">
+                Foot note
+              </ModalTitle>
+            </ModalHeader>
+            <ModalBody>
+              <div
+                className={`${footNote && footNote.languageName}`}
+                dangerouslySetInnerHTML={{ __html: footNoteText }}
+              />
+            </ModalBody>
+          </Modal>}
       </div>
     );
   }

--- a/src/containers/App/index.js
+++ b/src/containers/App/index.js
@@ -8,7 +8,6 @@ import Helmet from 'react-helmet';
 import Modal from 'react-bootstrap/lib/Modal';
 import Loadable from 'react-loadable';
 import ComponentLoader from 'components/ComponentLoader';
-import GlobalNav from 'components/GlobalNav';
 import debug from 'helpers/debug';
 import config from 'config';
 import metricsConfig from 'helpers/metrics';
@@ -23,6 +22,11 @@ const ModalHeader = Modal.Header;
 const ModalTitle = Modal.Title;
 const ModalBody = Modal.Body;
 
+const GlobalNav = Loadable({
+  loader: () => import('components/GlobalNav'),
+  LoadingComponent: ComponentLoader
+});
+
 const GlobalSidebar = Loadable({
   loader: () => import('components/GlobalSidebar'),
   LoadingComponent: ComponentLoader
@@ -34,14 +38,13 @@ const SmartBanner = Loadable({
 });
 
 class App extends Component {
-
   static contextTypes = {
     store: PropTypes.object.isRequired
   };
 
   state = {
     sidebarOpen: false
-  }
+  };
 
   render() {
     const {
@@ -81,23 +84,24 @@ class App extends Component {
             </div>
           </div>
         </NoScript>
-        {
-          React.cloneElement(
-            nav || <GlobalNav isStatic {...props} />,
-            {
-              handleSidebarToggle: () => this.setState({ sidebarOpen: !this.state.sidebarOpen })
-            }
-          )
-        }
-        <GlobalSidebar
-          open={this.state.sidebarOpen}
-          handleOpen={open => this.setState({ sidebarOpen: open })}
-        />
+        {React.cloneElement(nav || <GlobalNav isStatic {...props} />, {
+          handleSidebarToggle: () =>
+            this.setState({ sidebarOpen: !this.state.sidebarOpen })
+        })}
+        {__CLIENT__ &&
+          <GlobalSidebar
+            open={this.state.sidebarOpen}
+            handleOpen={open => this.setState({ sidebarOpen: open })}
+          />}
         {children || main}
         <SmartBanner title="The Noble Quran - القرآن الكريم" button="Install" />
         <Footer />
 
-        <Modal bsSize="large" show={media && media.content} onHide={removeMedia}>
+        <Modal
+          bsSize="large"
+          show={media && media.content}
+          onHide={removeMedia}
+        >
           <ModalHeader closeButton>
             <ModalTitle className="montserrat">
               {media.content && media.content.authorName}
@@ -106,12 +110,18 @@ class App extends Component {
           <ModalBody>
             <div
               className="embed-responsive embed-responsive-16by9"
-              dangerouslySetInnerHTML={{ __html: media.content && media.content.embedText }}
+              dangerouslySetInnerHTML={{
+                __html: media.content && media.content.embedText
+              }}
             />
           </ModalBody>
         </Modal>
 
-        <Modal bsSize="large" show={!!footNote || loadingFootNote} onHide={removeFootNote}>
+        <Modal
+          bsSize="large"
+          show={!!footNote || loadingFootNote}
+          onHide={removeFootNote}
+        >
           <ModalHeader closeButton>
             <ModalTitle className="montserrat">
               Foot note

--- a/src/containers/Home/index.js
+++ b/src/containers/Home/index.js
@@ -26,18 +26,28 @@ const Home = (props) => {
       <div className={`container ${styles.list}`}>
         <div className="row">
           <div className="col-md-10 col-md-offset-1">
-            {
-              lastVisit &&
-              <LastVisit chapter={props.chapters[lastVisit.chapterId]} verse={lastVisit.verseId} />
-            }
+            {lastVisit &&
+              <LastVisit
+                chapter={props.chapters[lastVisit.chapterId]}
+                verse={lastVisit.verseId}
+              />}
             <QuickSurahs />
             <h4 className={`text-muted ${styles.title}`}>
-              <LocaleFormattedMessage id="surah.index.heading" defaultMessage="SURAHS (CHAPTERS)" />
+              <LocaleFormattedMessage
+                id="surah.index.heading"
+                defaultMessage="SURAHS (CHAPTERS)"
+              />
             </h4>
             <div className="row">
-              <SurahsList chapters={Object.values(props.chapters).slice(0, 38)} />
-              <SurahsList chapters={Object.values(props.chapters).slice(38, 76)} />
-              <SurahsList chapters={Object.values(props.chapters).slice(76, 114)} />
+              <SurahsList
+                chapters={Object.values(props.chapters).slice(0, 38)}
+              />
+              <SurahsList
+                chapters={Object.values(props.chapters).slice(38, 76)}
+              />
+              <SurahsList
+                chapters={Object.values(props.chapters).slice(76, 114)}
+              />
             </div>
           </div>
         </div>
@@ -50,14 +60,18 @@ Home.propTypes = {
   chapters: customPropTypes.chapters.isRequired
 };
 
-const AsyncHome = asyncConnect([{
-  promise({ store: { getState, dispatch } }) {
-    if (!isAllLoaded(getState())) {
-      return dispatch(loadAll());
+const AsyncHome = asyncConnect([
+  {
+    promise({ store: { getState, dispatch } }) {
+      if (!isAllLoaded(getState())) {
+        return dispatch(loadAll());
+      }
+
+      return true;
     }
-
-    return true;
   }
-}])(Home);
+])(Home);
 
-export default connect(state => ({ chapters: state.chapters.entities }))(AsyncHome);
+export default connect(state => ({ chapters: state.chapters.entities }))(
+  AsyncHome
+);

--- a/src/containers/Surah/index.js
+++ b/src/containers/Surah/index.js
@@ -370,7 +370,7 @@ class Surah extends Component {
               onClose={this.handleSurahInfoToggle}
             />
             <div className="col-md-10 col-md-offset-1">
-              <TopOptions chapter={chapter} />
+              {__CLIENT__ && <TopOptions chapter={chapter} />}
               <Bismillah chapter={chapter} />
               {options.isReadingMode ? this.renderLines() : this.renderVerses()}
             </div>
@@ -379,11 +379,12 @@ class Surah extends Component {
             </div>
           </div>
         </div>
-        <Audioplayer
-          chapter={chapter}
-          startVerse={Object.values(verses)[0]}
-          onLoadAyahs={this.handleLazyLoadAyahs}
-        />
+        {__CLIENT__ &&
+          <Audioplayer
+            chapter={chapter}
+            startVerse={Object.values(verses)[0]}
+            onLoadAyahs={this.handleLazyLoadAyahs}
+          />}
       </div>
     );
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7446,9 +7446,11 @@ react-json-tree@0.5.5:
     babel-runtime "^6.3.13"
     react-mixin "^1.7.0"
 
-react-loadable@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/react-loadable/-/react-loadable-3.0.1.tgz#d285d0f32680fef3cf7c1fd8853206415f824ad8"
+react-loadable@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/react-loadable/-/react-loadable-3.3.1.tgz#91310f1c2adcc73ce944380ee9529f5d33e100d3"
+  dependencies:
+    babel-plugin-syntax-dynamic-import "^6.18.0"
 
 react-metrics@1.2.1:
   version "1.2.1"


### PR DESCRIPTION
Premise: `renderToString` is really slow, and even slower when there are more trees. Thus, if we get rid of components that require user interactions or do not contain links to render only on client, we can save some time! 

I am thinking I should make a util for this. Thoughts? 