### PR TITLE
Remove "The play() request was interrupted by a call to pause()"

### DIFF
--- a/src/components/Audioplayer/index.js
+++ b/src/components/Audioplayer/index.js
@@ -138,7 +138,12 @@ export class Audioplayer extends Component {
     if (!currentFile) return false;
 
     if (isPlaying) {
-      currentFile.play();
+      const playPromise = currentFile.play();
+      // Catch/silence error when a pause interrupts a play request
+      // on browsers which return a promise
+      if (playPromise !== undefined && typeof playPromise.then === 'function') {
+        playPromise.then(null, () => {});
+      }
     } else {
       currentFile.pause();
     }
@@ -374,7 +379,7 @@ export class Audioplayer extends Component {
     file.onloadeddata = null; // eslint-disable-line no-param-reassign
     file.ontimeupdate = null; // eslint-disable-line no-param-reassign
     file.onplay = null; // eslint-disable-line no-param-reassign
-    file.onPause = null; // eslint-disable-line no-param-reassign
+    file.onpause = null; // eslint-disable-line no-param-reassign
     file.onended = null; // eslint-disable-line no-param-reassign
     file.onprogress = null; // eslint-disable-line no-param-reassign
   };
@@ -471,7 +476,8 @@ export class Audioplayer extends Component {
 
     return (
       <div
-        className={`${isPlaying && style.isPlaying} ${style.container} ${className}`}
+        className={`${isPlaying &&
+          style.isPlaying} ${style.container} ${className}`}
       >
         <Wrapper>
           {currentFile &&
@@ -493,9 +499,7 @@ export class Audioplayer extends Component {
               id="player.currentVerse"
               defaultMessage="Ayah"
             />
-            :
-            {' '}
-            {currentVerse.verseKey.split(':')[1]}
+            : {currentVerse.verseKey.split(':')[1]}
           </ControlItem>
           <ControlItem>
             {this.renderPreviousButton()}


### PR DESCRIPTION
The pull request is addressed to close the [issue raised here](https://github.com/quran/quran.com-frontend/issues/786)

On Chrome, the ``` play() ``` method on an HTML Media Element returns a promise.
Since, the play method is asynchronous, if ``` pause() ``` method is called/triggered while a call to ``` play() ``` is in progress, Chrome throws an error stating
``` The play() request was interrupted by a call to pause() ```
The error thrown by Chrome doesn't break anything, it is just logged on the console.

On Browsers that return a promise, we can chain the play promise to catch any errors and ignore them.
