### PR TITLE
Fix audio player bar not loaded when changing chapter

### DIFF
--- a/src/components/Audioplayer/index.js
+++ b/src/components/Audioplayer/index.js
@@ -152,11 +152,15 @@ export class Audioplayer extends Component {
   }
 
   componentWillUnmount() {
-    const { files, currentFile } = this.props;
+    const { files, currentFile, update } = this.props;
     debug('component:Audioplayer', 'componentWillUnmount');
 
     if (files[currentFile]) {
       return this.handleRemoveFileListeners(files[currentFile]);
+    } else {
+      update({
+        currentTime: 0
+      })
     }
 
     return false;

--- a/src/components/Audioplayer/index.js
+++ b/src/components/Audioplayer/index.js
@@ -157,11 +157,11 @@ export class Audioplayer extends Component {
 
     if (files[currentFile]) {
       return this.handleRemoveFileListeners(files[currentFile]);
-    } else {
-      update({
-        currentTime: 0
-      })
     }
+
+    update({
+      currentTime: 0
+    });
 
     return false;
   }

--- a/src/containers/Surah/index.js
+++ b/src/containers/Surah/index.js
@@ -447,7 +447,7 @@ class Surah extends Component {
           <Audioplayer
             chapter={chapter}
             verses={verses}
-            currentVerse={verses[currentVerse]}
+            currentVerse={verses[currentVerse] || verses[Object.keys(verses)[0]]}
             onLoadAyahs={this.handleLazyLoadAyahs}
           />}
       </div>


### PR DESCRIPTION
Assalamualaikum
Bismillah this is my first contribution.
Insha Allah this commit will fix issue [815](https://github.com/quran/quran.com-frontend/issues/815) and [830](https://github.com/quran/quran.com-frontend/issues/830) and maybe [675](https://github.com/quran/quran.com-frontend/issues/675) too

- Fix currentVerse undefined
I found when user change verse, the currentVerse is not changed. So if user already on 4th verse on Surah 1 and move to Surah 3 for example, it will cause Audioplayer breaks (on staging, and endless loading on production) because `ownProps.currentVerse` is undefined on `files[ownProps.currentVerse.verseKey]` (on Audioplayer/index.js). 
This is caused by undefined `verses[currentVerse]' on 'Surah/index.js` upon rendering Audioplayer.
When new surah loads, `verses` will be assigned by `state.verses.entities[chapterId]` so it will be filled with {3:1, 3:2, 3:3 ...}.
So it will be undefined since `currentVerse` is still on `1:4` and verses[1:4] does not exist.
This fix will assign `currentVerse` to first element from verses when it is undefined.

- Restart currentTime to 0 when chapter changed
After audio player succesfully loaded, the state of `currentTime` did not change. So if the player already played to half of the ayah, it won't reset to `0` in new Surah.
This fix will reset the `currentTime` to 0 every unmounting Audioplayer element.