### PR TITLE
Return 404 when no routes found

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7239,7 +7239,6 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-1.3.6.tgz",
       "integrity": "sha1-4Oc7k+QXE40c18C3RrGkoUhUwpI=",
-      "dev": true,
       "requires": {
         "stackframe": "0.3.1"
       }
@@ -8094,7 +8093,8 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
     },
     "fast-memoize": {
       "version": "2.2.8",
@@ -18542,6 +18542,11 @@
         "object-assign": "4.1.1"
       }
     },
+    "react-deep-force-update": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/react-deep-force-update/-/react-deep-force-update-2.1.1.tgz",
+      "integrity": "sha1-jqQmPNZFWgULN0RbPwj9g52G6Qk="
+    },
     "react-docgen": {
       "version": "2.20.0",
       "resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-2.20.0.tgz",
@@ -18638,15 +18643,32 @@
       "integrity": "sha512-d7nZf78irxoGN5PY4zd6CSgZiroOhvIWzRast3qwTn4sSnBwlt08kV8WMQ9mitmxEdlCTwZt+5ClrRSjxWguMQ==",
       "requires": {
         "global": "4.3.2",
-        "hoist-non-react-statics": "2.3.1",
-        "prop-types": "15.6.0",
-        "react-stand-in": "4.0.0-beta.21"
+        "react-deep-force-update": "2.1.1",
+        "react-proxy": "3.0.0-alpha.1",
+        "redbox-react": "1.5.0",
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "hoist-non-react-statics": {
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz",
           "integrity": "sha1-ND24TGAYxlB3iJgkATWhQg7iLOA="
+        },
+        "redbox-react": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/redbox-react/-/redbox-react-1.5.0.tgz",
+          "integrity": "sha512-mdxArOI3sF8K5Nay5NG+lv/VW516TbXjjd4h1wcV1Iy4IMDQPnCayjoQXBAycAFSME4nyXRUXCjHxsw2rYpVRw==",
+          "requires": {
+            "error-stack-parser": "1.3.6",
+            "object-assign": "4.1.1",
+            "prop-types": "15.6.0",
+            "sourcemapped-stacktrace": "1.1.7"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
     },
@@ -18819,6 +18841,14 @@
       "integrity": "sha1-+ZsL+0AGkpya8gUefBQUpcdbk9A=",
       "requires": {
         "warning": "3.0.0"
+      }
+    },
+    "react-proxy": {
+      "version": "3.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/react-proxy/-/react-proxy-3.0.0-alpha.1.tgz",
+      "integrity": "sha1-RABCa8+oDKpnJMd1VpUxUgn6Swc=",
+      "requires": {
+        "lodash": "4.17.4"
       }
     },
     "react-pure-render": {
@@ -19037,21 +19067,6 @@
         "inline-style-prefixer": "3.0.8",
         "prop-types": "15.6.0",
         "react-style-proptype": "3.1.0"
-      }
-    },
-    "react-stand-in": {
-      "version": "4.0.0-beta.21",
-      "resolved": "https://registry.npmjs.org/react-stand-in/-/react-stand-in-4.0.0-beta.21.tgz",
-      "integrity": "sha1-+2lORlyyD6t/NtMoT4K2i716ZX4=",
-      "requires": {
-        "shallowequal": "1.0.2"
-      },
-      "dependencies": {
-        "shallowequal": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.0.2.tgz",
-          "integrity": "sha512-zlVXeVUKvo+HEv1e2KQF/csyeMKx2oHvatQ9l6XjCUj3agvC8XGf6R9HvIPDSmp8FNPvx7b5kaEJTRi7CqxtEw=="
-        }
       }
     },
     "react-style-proptype": {
@@ -20744,7 +20759,6 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/sourcemapped-stacktrace/-/sourcemapped-stacktrace-1.1.7.tgz",
       "integrity": "sha512-pgHNUACbafkQ+M5zR00NSOtSKBc/i40prgN+SY07J/pghClwVNWNTTMa0JuXj4lriR2TvMKcPAHw5KN9tVFRhA==",
-      "dev": true,
       "requires": {
         "source-map": "0.5.6"
       },
@@ -20752,8 +20766,7 @@
         "source-map": {
           "version": "0.5.6",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
-          "dev": true
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
         }
       }
     },
@@ -20900,8 +20913,7 @@
     "stackframe": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-0.3.1.tgz",
-      "integrity": "sha1-M6qE8Rd6VUjIk1Uzy/6zQgl19aQ=",
-      "dev": true
+      "integrity": "sha1-M6qE8Rd6VUjIk1Uzy/6zQgl19aQ="
     },
     "staged-git-files": {
       "version": "0.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7239,6 +7239,7 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-1.3.6.tgz",
       "integrity": "sha1-4Oc7k+QXE40c18C3RrGkoUhUwpI=",
+      "dev": true,
       "requires": {
         "stackframe": "0.3.1"
       }
@@ -8093,8 +8094,7 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-      "dev": true
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "fast-memoize": {
       "version": "2.2.8",
@@ -18542,11 +18542,6 @@
         "object-assign": "4.1.1"
       }
     },
-    "react-deep-force-update": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/react-deep-force-update/-/react-deep-force-update-2.1.1.tgz",
-      "integrity": "sha1-jqQmPNZFWgULN0RbPwj9g52G6Qk="
-    },
     "react-docgen": {
       "version": "2.20.0",
       "resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-2.20.0.tgz",
@@ -18643,27 +18638,15 @@
       "integrity": "sha512-d7nZf78irxoGN5PY4zd6CSgZiroOhvIWzRast3qwTn4sSnBwlt08kV8WMQ9mitmxEdlCTwZt+5ClrRSjxWguMQ==",
       "requires": {
         "global": "4.3.2",
-        "react-deep-force-update": "2.1.1",
-        "react-proxy": "3.0.0-alpha.1",
-        "redbox-react": "1.5.0",
-        "source-map": "0.6.1"
+        "hoist-non-react-statics": "2.3.1",
+        "prop-types": "15.6.0",
+        "react-stand-in": "4.0.0-beta.21"
       },
       "dependencies": {
-        "redbox-react": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/redbox-react/-/redbox-react-1.5.0.tgz",
-          "integrity": "sha512-mdxArOI3sF8K5Nay5NG+lv/VW516TbXjjd4h1wcV1Iy4IMDQPnCayjoQXBAycAFSME4nyXRUXCjHxsw2rYpVRw==",
-          "requires": {
-            "error-stack-parser": "1.3.6",
-            "object-assign": "4.1.1",
-            "prop-types": "15.6.0",
-            "sourcemapped-stacktrace": "1.1.7"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        "hoist-non-react-statics": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz",
+          "integrity": "sha1-ND24TGAYxlB3iJgkATWhQg7iLOA="
         }
       }
     },
@@ -18836,14 +18819,6 @@
       "integrity": "sha1-+ZsL+0AGkpya8gUefBQUpcdbk9A=",
       "requires": {
         "warning": "3.0.0"
-      }
-    },
-    "react-proxy": {
-      "version": "3.0.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/react-proxy/-/react-proxy-3.0.0-alpha.1.tgz",
-      "integrity": "sha1-RABCa8+oDKpnJMd1VpUxUgn6Swc=",
-      "requires": {
-        "lodash": "4.17.4"
       }
     },
     "react-pure-render": {
@@ -19062,6 +19037,21 @@
         "inline-style-prefixer": "3.0.8",
         "prop-types": "15.6.0",
         "react-style-proptype": "3.1.0"
+      }
+    },
+    "react-stand-in": {
+      "version": "4.0.0-beta.21",
+      "resolved": "https://registry.npmjs.org/react-stand-in/-/react-stand-in-4.0.0-beta.21.tgz",
+      "integrity": "sha1-+2lORlyyD6t/NtMoT4K2i716ZX4=",
+      "requires": {
+        "shallowequal": "1.0.2"
+      },
+      "dependencies": {
+        "shallowequal": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.0.2.tgz",
+          "integrity": "sha512-zlVXeVUKvo+HEv1e2KQF/csyeMKx2oHvatQ9l6XjCUj3agvC8XGf6R9HvIPDSmp8FNPvx7b5kaEJTRi7CqxtEw=="
+        }
       }
     },
     "react-style-proptype": {
@@ -20754,6 +20744,7 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/sourcemapped-stacktrace/-/sourcemapped-stacktrace-1.1.7.tgz",
       "integrity": "sha512-pgHNUACbafkQ+M5zR00NSOtSKBc/i40prgN+SY07J/pghClwVNWNTTMa0JuXj4lriR2TvMKcPAHw5KN9tVFRhA==",
+      "dev": true,
       "requires": {
         "source-map": "0.5.6"
       },
@@ -20761,7 +20752,8 @@
         "source-map": {
           "version": "0.5.6",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+          "dev": true
         }
       }
     },
@@ -20908,7 +20900,8 @@
     "stackframe": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-0.3.1.tgz",
-      "integrity": "sha1-M6qE8Rd6VUjIk1Uzy/6zQgl19aQ="
+      "integrity": "sha1-M6qE8Rd6VUjIk1Uzy/6zQgl19aQ=",
+      "dev": true
     },
     "staged-git-files": {
       "version": "0.0.4",

--- a/src/components/NotFound/index.js
+++ b/src/components/NotFound/index.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import Status from '../Status';
+import LocaleFormattedMessage from '../LocaleFormattedMessage';
+import IndexHeader from '../IndexHeader';
+
+const Container = styled.div`
+  padding: 20vh 0;
+`;
+
+const NotFound = () => (
+  <Status code={404}>
+    <div>
+      <IndexHeader noSearch />
+      <div className="row">
+        <div className="col-md-8 col-md-offset-2 text-center">
+          <Container>
+            <h3 className="source-sans">
+              <LocaleFormattedMessage
+                id="error.not-found"
+                defaultMessage="Sorry, this page does not exist"
+              />
+            </h3>
+          </Container>
+        </div>
+      </div>
+    </div>
+  </Status>
+);
+
+export default NotFound;

--- a/src/components/Status/index.js
+++ b/src/components/Status/index.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Route } from 'react-router';
+
+const propTypes = {
+  code: PropTypes.number.isRequired,
+  children: PropTypes.node.isRequired
+};
+
+const Status = ({ code, children }) => (
+  <Route
+    render={({ staticContext }) => {
+      if (staticContext) {
+        // eslint-disable-next-line
+        staticContext.status = code;
+      }
+
+      return children;
+    }}
+  />
+);
+
+Status.propTypes = propTypes;
+
+export default Status;

--- a/src/components/Status/spec.js
+++ b/src/components/Status/spec.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { Route } from 'react-router';
+
+import Status from './index';
+
+describe('<Status />', () => {
+  test('should render valid', () => {
+    expect(
+      React.isValidElement(
+        <Status code={404}>
+          <div />
+        </Status>
+      )
+    ).toBeTruthy();
+  });
+
+  test('should render Route', () => {
+    const wrapper = shallow(
+      <Status code={404}>
+        <div />
+      </Status>
+    );
+
+    expect(wrapper.find(Route)).toHaveLength(1);
+  });
+});

--- a/src/locale/en.js
+++ b/src/locale/en.js
@@ -88,6 +88,7 @@ export default {
     'error.invalid-surah':
       "Surah is out of range. Please go to <a href='/'> home page</a> and select a Surah",
     'error.invalid-ayah':
-      "Ayah is out of range. Please go to <a href='/'> home page </a> and select a Surah/Ayah"
+      "Ayah is out of range. Please go to <a href='/'> home page </a> and select a Surah/Ayah",
+    'error.not-found': 'Sorry, this page does not exist'
   }
 };

--- a/src/routes.js
+++ b/src/routes.js
@@ -4,6 +4,7 @@ import loadable from 'loadable-components';
 import { Switch, Route } from 'react-router';
 
 import Home from './containers/Home';
+import NotFound from './components/NotFound';
 
 import {
   chaptersConnect,
@@ -191,6 +192,7 @@ const Routes = ({ store }) => (
         }}
       />
     ))}{' '}
+    <Route component={NotFound} />
   </Switch>
 );
 


### PR DESCRIPTION
### Title of change
Currently, we don't return 404 when you go to not found urls. Example of that is `http://localhost:8000/public/dist/main.js`
### Checklist

- [x] Unit tests written
- [x] Manually tested
- [x] Prettier & ESLint were run
- [x] New dependencies are included in `package-lock.json`

### Screenshot
![image](https://user-images.githubusercontent.com/3749095/35849271-e1486b3c-0ad5-11e8-9deb-31330a246f3f.png)

