### PR TITLE
Move the surah info into a container

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,7 +16,7 @@
     "classes": true,
     "jsx": true
   },
-  "plugins": ["react"],
+  "plugins": ["react", "jest"],
   "settings": {
     "import/resolver": "webpack"
   },
@@ -46,6 +46,7 @@
   },
   "env": {
     "mocha": true,
-    "amd": true
+    "amd": true,
+    "jest/globals": true
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7946,6 +7946,12 @@
         }
       }
     },
+    "eslint-plugin-jest": {
+      "version": "21.15.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-21.15.0.tgz",
+      "integrity": "sha512-Qe1egBnn0obmFQ9quZiJwwsf1H6oBXrJBku7OUt8XdCSwKL6h7xC4OKyg2px9jQXxv7YcTNUIFAGk2OUpPfDOA==",
+      "dev": true
+    },
     "eslint-plugin-jsx-a11y": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-2.2.3.tgz",

--- a/package.json
+++ b/package.json
@@ -40,8 +40,7 @@
       "./setupJest.js"
     ],
     "moduleNameMapper": {
-      "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$":
-        "<rootDir>/tests/__mocks__/fileMock.js",
+      "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/tests/__mocks__/fileMock.js",
       "\\.(css|scss)$": "<rootDir>/tests/__mocks__/styleMock.js"
     }
   },

--- a/package.json
+++ b/package.json
@@ -42,6 +42,9 @@
     "moduleNameMapper": {
       "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/tests/__mocks__/fileMock.js",
       "\\.(css|scss)$": "<rootDir>/tests/__mocks__/styleMock.js"
+    },
+    "globals": {
+      "__CLIENT__": true
     }
   },
   "pre-commit": [

--- a/package.json
+++ b/package.json
@@ -38,7 +38,12 @@
     "automock": false,
     "setupFiles": [
       "./setupJest.js"
-    ]
+    ],
+    "moduleNameMapper": {
+      "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$":
+        "<rootDir>/tests/__mocks__/fileMock.js",
+      "\\.(css|scss)$": "<rootDir>/tests/__mocks__/styleMock.js"
+    }
   },
   "pre-commit": [
     "test:stylelint",
@@ -186,6 +191,7 @@
     "eslint": "3.12.2",
     "eslint-config-airbnb": "13.0.0",
     "eslint-plugin-import": "2.2.0",
+    "eslint-plugin-jest": "21.15.0",
     "eslint-plugin-jsx-a11y": "2.2.3",
     "eslint-plugin-mocha": "4.8.0",
     "eslint-plugin-react": "6.8.0",

--- a/src/components/ChapterInfoPanel/index.js
+++ b/src/components/ChapterInfoPanel/index.js
@@ -5,6 +5,8 @@ import styled from 'styled-components';
 import { lighten } from 'polished';
 import Loader from 'quran-components/lib/Loader';
 
+import LocaleFormattedMessage from 'components/LocaleFormattedMessage';
+
 import madinah from '../../../static/images/madinah.jpg';
 import makkah from '../../../static/images/makkah.jpg';
 
@@ -110,10 +112,10 @@ const ListContainer = styled.div`
   }
 `;
 
-const SurahInfo = ({ chapter, info, isShowingSurahInfo, setOption }) => {
+const SurahInfo = ({ chapter, chapterInfo, isShowingSurahInfo, setOption }) => {
   // So we don't need to load images and files unless needed
   if (!isShowingSurahInfo) return <noscript />;
-  if (!info) return <Loader isActive />;
+  if (!chapterInfo) return <Loader isActive />;
 
   const handleClose = () =>
     setOption({ isShowingSurahInfo: !isShowingSurahInfo });
@@ -130,17 +132,27 @@ const SurahInfo = ({ chapter, info, isShowingSurahInfo, setOption }) => {
         />
         <ListContainer className="col-md-1 col-xs-6">
           <List>
-            <dt>VERSES</dt>
+            <dt>
+              <LocaleFormattedMessage
+                id="chapterInfo.verses"
+                defaultMessage="VERSES"
+              />
+            </dt>
             <dd className="text-uppercase">{chapter.versesCount}</dd>
-            <dt>PAGES</dt>
+            <dt>
+              <LocaleFormattedMessage
+                id="chapterInfo.pages"
+                defaultMessage="PAGES"
+              />
+            </dt>
             <dd className="text-uppercase">{chapter.pages.join('-')}</dd>
           </List>
         </ListContainer>
-        <Info className={`${info.languageName} times-new col-md-8`}>
-          <div dangerouslySetInnerHTML={{ __html: info.text }} />
+        <Info className={`${chapterInfo.languageName} times-new col-md-8`}>
+          <div dangerouslySetInnerHTML={{ __html: chapterInfo.text }} />
           <div>
             <p>
-              <em>Source: {info.source}</em>
+              <em>Source: {chapterInfo.source}</em>
             </p>
           </div>
         </Info>
@@ -153,7 +165,7 @@ SurahInfo.propTypes = {
   setOption: PropTypes.func.isRequired,
   isShowingSurahInfo: PropTypes.bool.isRequired,
   chapter: customPropTypes.surahType,
-  info: customPropTypes.infoType
+  chapterInfo: customPropTypes.infoType
 };
 
 export default SurahInfo;

--- a/src/components/ChapterInfoPanel/spec.js
+++ b/src/components/ChapterInfoPanel/spec.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { chapter } from '../../../tests/fixtures/chapters';
+import { chapterInfo } from '../../../tests/fixtures/chapterInfos';
+import ChapterInfoPanel from './index';
+
+let wrapper;
+let props;
+
+describe('<ChapterInfoPanel />', () => {
+  beforeEach(() => {
+    props = {
+      setOption: jest.fn(),
+      isShowingSurahInfo: true,
+      chapter,
+      chapterInfo
+    };
+
+    wrapper = shallow(<ChapterInfoPanel {...props} />);
+  });
+
+  it('should render', () => {
+    expect(wrapper).toBeTruthy();
+  });
+});

--- a/src/components/Navbars/index.js
+++ b/src/components/Navbars/index.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import loadable from 'loadable-components';
+import { Switch, Route } from 'react-router';
+
+import routes from '../../routes';
+
+const GlobalNav = loadable(() =>
+  import(/* webpackChunkName: "GlobalNav" */ 'components/GlobalNav')
+);
+
+// eslint-disable-next-line no-unused-vars
+const Navbars = ({ match, ...props }) => (
+  <Switch>
+    {' '}
+    {routes
+      .filter(route => route.navbar)
+      // eslint-disable-next-line no-unused-vars
+      .map(({ navbar: Navbar, component, ...route }) => (
+        <Route
+          key={route.path}
+          {...route}
+          render={routeProps => <Navbar {...routeProps} {...props} />}
+        />
+      ))}{' '}
+    <Route
+      render={routeProps => <GlobalNav {...routeProps} {...props} isStatic />}
+    />{' '}
+  </Switch>
+);
+
+Navbars.propTypes = {
+  // eslint-disable-next-line
+  match: PropTypes.object
+};
+
+export default Navbars;

--- a/src/components/Routes/index.js
+++ b/src/components/Routes/index.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Switch, Route } from 'react-router';
+
+import routes from '../../routes';
+import NotFound from '../NotFound';
+import routePromises from '../../utils/routePromises';
+
+const defaultSetContext = context => ({
+  ...context,
+  status: 200
+});
+
+const Routes = ({ store }) => (
+  <Switch>
+    {routes.map(({ component: Component, loadData, setContext, ...route }) => (
+      <Route
+        key={route.path}
+        {...route}
+        render={({ staticContext, ...routeProps }) => {
+          if (staticContext) {
+            const contextFunction = setContext || defaultSetContext;
+
+            Object.assign(staticContext, contextFunction(staticContext));
+          }
+
+          if (__CLIENT__) {
+            routePromises({
+              store,
+              match: routeProps.match,
+              loadData
+            }).then(() => <Component {...routeProps} />);
+          }
+
+          return <Component {...routeProps} />;
+        }}
+      />
+    ))}{' '}
+    <Route component={NotFound} />
+  </Switch>
+);
+
+Routes.propTypes = {
+  store: PropTypes.object.isRequired // eslint-disable-line
+};
+
+export default Routes;

--- a/src/components/SurahInfo/index.js
+++ b/src/components/SurahInfo/index.js
@@ -110,18 +110,19 @@ const ListContainer = styled.div`
   }
 `;
 
-const SurahInfo = ({ chapter, info, isShowingSurahInfo, onClose }) => {
+const SurahInfo = ({ chapter, info, isShowingSurahInfo, setOption }) => {
   // So we don't need to load images and files unless needed
   if (!isShowingSurahInfo) return <noscript />;
   if (!info) return <Loader isActive />;
 
   const handleClose = () =>
-    onClose({ isShowingSurahInfo: !isShowingSurahInfo });
+    setOption({ isShowingSurahInfo: !isShowingSurahInfo });
 
   return (
     <Container className="col-xs-12 chapter-info">
-      {onClose &&
-        <Close tabIndex="-1" className="ss-delete" onClick={handleClose} />}
+      {setOption && (
+        <Close tabIndex="-1" className="ss-delete" onClick={handleClose} />
+      )}
       <div className="row" style={{ width: '100%', height: '100%', margin: 0 }}>
         <Image
           className="col-md-3 col-xs-6"
@@ -130,22 +131,16 @@ const SurahInfo = ({ chapter, info, isShowingSurahInfo, onClose }) => {
         <ListContainer className="col-md-1 col-xs-6">
           <List>
             <dt>VERSES</dt>
-            <dd className="text-uppercase">
-              {chapter.versesCount}
-            </dd>
+            <dd className="text-uppercase">{chapter.versesCount}</dd>
             <dt>PAGES</dt>
-            <dd className="text-uppercase">
-              {chapter.pages.join('-')}
-            </dd>
+            <dd className="text-uppercase">{chapter.pages.join('-')}</dd>
           </List>
         </ListContainer>
         <Info className={`${info.languageName} times-new col-md-8`}>
           <div dangerouslySetInnerHTML={{ __html: info.text }} />
           <div>
             <p>
-              <em>
-                Source: {info.source}
-              </em>
+              <em>Source: {info.source}</em>
             </p>
           </div>
         </Info>
@@ -155,8 +150,8 @@ const SurahInfo = ({ chapter, info, isShowingSurahInfo, onClose }) => {
 };
 
 SurahInfo.propTypes = {
-  onClose: PropTypes.func,
-  isShowingSurahInfo: PropTypes.bool,
+  setOption: PropTypes.func.isRequired,
+  isShowingSurahInfo: PropTypes.bool.isRequired,
   chapter: customPropTypes.surahType,
   info: customPropTypes.infoType
 };

--- a/src/containers/App/index.js
+++ b/src/containers/App/index.js
@@ -17,7 +17,8 @@ import NoScript from 'components/NoScript';
 import { removeMedia } from 'redux/actions/media';
 import Loader from 'quran-components/lib/Loader';
 
-import Routes, { Navbars } from '../../routes';
+import Routes from '../../components/Routes';
+import Navbars from '../../components/Navbars';
 
 const ModalHeader = Modal.Header;
 const ModalTitle = Modal.Title;

--- a/src/containers/ChapterInfo/index.js
+++ b/src/containers/ChapterInfo/index.js
@@ -76,11 +76,10 @@ ChapterInfo.propTypes = {
 
 function mapStateToProps(state, ownProps) {
   const chapterId = parseInt(ownProps.match.params.chapterId, 10);
-  const chapter = state.chapters.entities[chapterId];
 
   return {
     chapter: state.chapters.entities[chapterId],
-    chapterInfo: state.chapterinfos.entities[chapterId]
+    chapterInfo: state.chapterInfos.entities[chapterId]
   };
 }
 

--- a/src/containers/ChapterInfo/index.js
+++ b/src/containers/ChapterInfo/index.js
@@ -9,18 +9,20 @@ import ComponentLoader from 'components/ComponentLoader';
 import LocaleFormattedMessage from 'components/LocaleFormattedMessage';
 import makeHeadTags from 'helpers/makeHeadTags';
 
-const SurahInfo = Loadable({
+const ChapterInfoPanel = Loadable({
   loader: () =>
-    import(/* webpackChunkName: "SurahInfo" */ 'components/SurahInfo'),
+    import(/* webpackChunkName: "ChapterInfoPanel" */ 'components/ChapterInfoPanel'),
   LoadingComponent: ComponentLoader
 });
 
-const ChapterInfo = ({ chapter, info }) => (
+const ChapterInfo = ({ chapter, chapterInfo }) => (
   <div className="row" style={{ marginTop: 20 }}>
     <Helmet
       {...makeHeadTags({
         title: `Surah ${chapter.nameSimple} [${chapter.chapterNumber}]`,
-        description: `${info ? info.shortText : ''} This Surah has ${
+        description: `${
+          chapterInfo ? chapterInfo.shortText : ''
+        } This Surah has ${
           chapter.versesCount
         } verses and resides between pages ${chapter.pages[0]} to ${
           chapter.pages[1]
@@ -51,7 +53,11 @@ const ChapterInfo = ({ chapter, info }) => (
         }
       ]}
     />
-    <SurahInfo chapter={chapter} info={info} isShowingSurahInfo />
+    <ChapterInfoPanel
+      chapter={chapter}
+      chapterInfo={chapterInfo}
+      isShowingSurahInfo
+    />
     <div className="text-center">
       <Button href={`/${chapter.id}`}>
         <LocaleFormattedMessage
@@ -65,7 +71,7 @@ const ChapterInfo = ({ chapter, info }) => (
 
 ChapterInfo.propTypes = {
   chapter: customPropTypes.surahType,
-  info: customPropTypes.infoType
+  chapterInfo: customPropTypes.infoType
 };
 
 function mapStateToProps(state, ownProps) {
@@ -73,8 +79,8 @@ function mapStateToProps(state, ownProps) {
   const chapter = state.chapters.entities[chapterId];
 
   return {
-    chapter,
-    info: state.chapters.infos[chapterId]
+    chapter: state.chapters.entities[chapterId],
+    chapterInfo: state.chapterinfos.entities[chapterId]
   };
 }
 

--- a/src/containers/ChapterInfoPanelContainer/index.js
+++ b/src/containers/ChapterInfoPanelContainer/index.js
@@ -1,0 +1,11 @@
+import { connect } from 'react-redux';
+
+import SurahInfo from 'components/SurahInfo';
+import { setOption } from 'redux/actions/options';
+
+const mapStateToProps = (state, ownProps) => ({
+  chapterInfo: state.chapterInfos.entities[ownProps.chapter.id],
+  isShowingSurahInfo: state.options.isShowingSurahInfo
+});
+
+export default connect(mapStateToProps, { setOption })(SurahInfo);

--- a/src/containers/ChapterInfoPanelContainer/index.js
+++ b/src/containers/ChapterInfoPanelContainer/index.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 
-import SurahInfo from 'components/SurahInfo';
+import ChapterInfoPanel from 'components/ChapterInfoPanel';
 import { setOption } from 'redux/actions/options';
 
 const mapStateToProps = (state, ownProps) => ({
@@ -8,4 +8,4 @@ const mapStateToProps = (state, ownProps) => ({
   isShowingSurahInfo: state.options.isShowingSurahInfo
 });
 
-export default connect(mapStateToProps, { setOption })(SurahInfo);
+export default connect(mapStateToProps, { setOption })(ChapterInfoPanel);

--- a/src/containers/Surah/connect.js
+++ b/src/containers/Surah/connect.js
@@ -1,10 +1,12 @@
 import {
   isAllLoaded,
   loadAll,
-  loadChapterInfo,
   setCurrent as setCurrentSurah
 } from 'redux/actions/chapters.js';
-import { isChapterInfoLoaded } from 'redux/actions/chapterInfos';
+import {
+  isChapterInfoLoaded,
+  loadChapterInfo
+} from 'redux/actions/chapterInfos';
 
 import {
   clearCurrent,

--- a/src/containers/Surah/connect.js
+++ b/src/containers/Surah/connect.js
@@ -1,10 +1,10 @@
 import {
   isAllLoaded,
   loadAll,
-  loadInfo,
-  setCurrent as setCurrentSurah,
-  isInfoLoaded
+  loadChapterInfo,
+  setCurrent as setCurrentSurah
 } from 'redux/actions/chapters.js';
+import { isChapterInfoLoaded } from 'redux/actions/chapterInfos';
 
 import {
   clearCurrent,
@@ -78,14 +78,14 @@ export const chapterInfoConnect = ({
   store: { dispatch, getState },
   params
 }) => {
-  if (isInfoLoaded(getState(), params.chapterId)) return false;
+  if (isChapterInfoLoaded(getState(), params.chapterId)) return false;
 
   if (__CLIENT__) {
-    dispatch(loadInfo(params));
+    dispatch(loadChapterInfo(params));
     return true;
   }
 
-  return dispatch(loadInfo(params));
+  return dispatch(loadChapterInfo(params));
 };
 
 export const versesConnect = ({

--- a/src/containers/Surah/index.js
+++ b/src/containers/Surah/index.js
@@ -42,9 +42,9 @@ const Audioplayer = Loadable({
     import(/* webpackChunkName: "Audioplayer" */ 'components/Audioplayer'),
   LoadingComponent: ComponentLoader
 });
-const SurahInfo = Loadable({
+const ChapterInfoPanelContainer = Loadable({
   loader: () =>
-    import(/* webpackChunkName: "SurahInfo" */ 'components/SurahInfo'),
+    import(/* webpackChunkName: "SurahInfo" */ 'containers/ChapterInfoPanelContainer'),
   LoadingComponent: ComponentLoader
 });
 const TopOptions = Loadable({
@@ -155,12 +155,6 @@ class Surah extends Component {
     }
 
     return false;
-  };
-
-  handleSurahInfoToggle = (payload) => {
-    const { actions } = this.props; // eslint-disable-line no-shadow
-
-    return actions.options.setOption(payload);
   };
 
   title() {
@@ -379,14 +373,7 @@ class Surah extends Component {
   }
 
   render() {
-    const {
-      chapter,
-      verses,
-      options,
-      info,
-      actions,
-      currentVerse
-    } = this.props; // eslint-disable-line no-shadow
+    const { chapter, verses, options, currentVerse } = this.props; // eslint-disable-line no-shadow
     debug('component:Surah', 'Render');
 
     if (!this.hasVerses()) {
@@ -440,13 +427,7 @@ class Surah extends Component {
         />
         <Container className="container-fluid">
           <div className="row">
-            <SurahInfo
-              chapter={chapter}
-              info={info}
-              loadInfo={actions.loadInfo}
-              isShowingSurahInfo={options.isShowingSurahInfo}
-              onClose={this.handleSurahInfoToggle}
-            />
+            <ChapterInfoPanelContainer chapter={chapter} />
             <div className="col-md-10 col-md-offset-1">
               {__CLIENT__ && <TopOptions chapter={chapter} />}
               <Bismillah chapter={chapter} />
@@ -512,7 +493,6 @@ function mapStateToProps(state, ownProps) {
     verseIds,
     isSingleAyah,
     currentVerse,
-    info: state.chapters.infos[ownProps.match.params.chapterId],
     isStarted: state.audioplayer.isStarted,
     isPlaying: state.audioplayer.isPlaying,
     currentWord: state.verses.currentWord,

--- a/src/redux/actions/chapterInfos.js
+++ b/src/redux/actions/chapterInfos.js
@@ -1,0 +1,22 @@
+import { FETCH_CHAPTER_INFO } from '../constants/chapters.js';
+import ApiClient from '../../helpers/ApiClient';
+
+const client = new ApiClient();
+
+export const loadChapterInfo = params => ({
+  types: [
+    FETCH_CHAPTER_INFO.ACTION,
+    FETCH_CHAPTER_INFO.SUCCESS,
+    FETCH_CHAPTER_INFO.FAIL
+  ],
+  promise: client.get(`/api/v3/chapters/${params.chapterId}/info`, {
+    params: {
+      language: params.language || 'en'
+    }
+  }),
+  id: params.chapterId
+});
+
+export function isChapterInfoLoaded(globalState, id) {
+  return globalState.chapters.entities[id] && globalState.chapters.infos[id];
+}

--- a/src/redux/actions/chapterInfos.js
+++ b/src/redux/actions/chapterInfos.js
@@ -1,4 +1,4 @@
-import { FETCH_CHAPTER_INFO } from '../constants/chapters.js';
+import { FETCH_CHAPTER_INFO } from '../constants/chapterInfos';
 import ApiClient from '../../helpers/ApiClient';
 
 const client = new ApiClient();

--- a/src/redux/actions/chapterInfos.js
+++ b/src/redux/actions/chapterInfos.js
@@ -7,16 +7,18 @@ export const loadChapterInfo = params => ({
   types: [
     FETCH_CHAPTER_INFO.ACTION,
     FETCH_CHAPTER_INFO.SUCCESS,
-    FETCH_CHAPTER_INFO.FAIL
+    FETCH_CHAPTER_INFO.FAIL,
   ],
   promise: client.get(`/api/v3/chapters/${params.chapterId}/info`, {
     params: {
-      language: params.language || 'en'
-    }
+      language: params.language || 'en',
+    },
   }),
-  id: params.chapterId
+  id: params.chapterId,
 });
 
 export function isChapterInfoLoaded(globalState, id) {
-  return globalState.chapters.entities[id] && globalState.chapters.infos[id];
+  return (
+    globalState.chapters.entities[id] && globalState.chapterInfos.entities[id]
+  );
 }

--- a/src/redux/actions/chapters.js
+++ b/src/redux/actions/chapters.js
@@ -1,9 +1,5 @@
 import { chaptersSchema } from 'redux/schemas';
-import {
-  FETCH_CHAPTERS,
-  FETCH_CHAPTER_INFO,
-  SET_CURRENT
-} from '../constants/chapters.js';
+import { FETCH_CHAPTERS, SET_CURRENT } from '../constants/chapters.js';
 import ApiClient from '../../helpers/ApiClient';
 
 const client = new ApiClient();
@@ -32,20 +28,6 @@ export function load(id) {
   };
 }
 
-export const loadInfo = params => ({
-  types: [
-    FETCH_CHAPTER_INFO.ACTION,
-    FETCH_CHAPTER_INFO.SUCCESS,
-    FETCH_CHAPTER_INFO.FAIL
-  ],
-  promise: client.get(`/api/v3/chapters/${params.chapterId}/info`, {
-    params: {
-      language: params.language || 'en'
-    }
-  }),
-  id: params.chapterId
-});
-
 export const setCurrent = id => ({
   type: SET_CURRENT.ACTION,
   current: id
@@ -57,8 +39,4 @@ export function isSingleLoaded(globalState, id) {
 
 export function isAllLoaded(globalState) {
   return Object.keys(globalState.chapters.entities).length === 114;
-}
-
-export function isInfoLoaded(globalState, id) {
-  return globalState.chapters.entities[id] && globalState.chapters.infos[id];
 }

--- a/src/redux/constants/chapterInfos.js
+++ b/src/redux/constants/chapterInfos.js
@@ -1,0 +1,9 @@
+import { defineAction } from 'redux-define';
+import states from './states';
+
+// eslint-disable-next-line import/prefer-default-export
+export const FETCH_CHAPTER_INFO = defineAction(
+  'FETCH_CHAPTER_INFO',
+  states,
+  'quran'
+);

--- a/src/redux/constants/chapters.js
+++ b/src/redux/constants/chapters.js
@@ -2,9 +2,4 @@ import { defineAction } from 'redux-define';
 import states from './states';
 
 export const FETCH_CHAPTERS = defineAction('FETCH_CHAPTERS', states, 'quran');
-export const FETCH_CHAPTER_INFO = defineAction(
-  'FETCH_CHAPTER_INFO',
-  states,
-  'quran'
-);
 export const SET_CURRENT = defineAction('SET_CURRENT', [], 'quran');

--- a/src/redux/reducers/chapterInfos.js
+++ b/src/redux/reducers/chapterInfos.js
@@ -1,0 +1,29 @@
+import { handleActions } from 'redux-actions';
+
+import { FETCH_CHAPTER_INFO } from '../constants/chapterInfos';
+
+export const INITIAL_STATE = {
+  errored: false,
+  loaded: false,
+  loading: false,
+  entities: {}
+};
+
+export default handleActions(
+  {
+    [FETCH_CHAPTER_INFO.ACTION]: state => ({
+      ...state,
+      loading: true
+    }),
+    [FETCH_CHAPTER_INFO.SUCCESS]: (state, { id, result }) => ({
+      ...state,
+      loading: false,
+      loaded: true,
+      entities: {
+        ...state.entities,
+        [id]: result.chapterInfo
+      }
+    })
+  },
+  INITIAL_STATE
+);

--- a/src/redux/reducers/chapters.js
+++ b/src/redux/reducers/chapters.js
@@ -1,10 +1,6 @@
 import { handleActions } from 'redux-actions';
 
-import {
-  FETCH_CHAPTERS,
-  FETCH_CHAPTER_INFO,
-  SET_CURRENT
-} from '../constants/chapters';
+import { FETCH_CHAPTERS, SET_CURRENT } from '../constants/chapters';
 
 export const INITIAL_STATE = {
   errored: false,
@@ -29,17 +25,6 @@ export default handleActions(
       };
     },
     [FETCH_CHAPTERS.FAILURE]: state => ({ ...state, errored: true }),
-    [FETCH_CHAPTER_INFO.ACTION]: state => ({
-      ...state,
-      infoLoading: true
-    }),
-    [FETCH_CHAPTER_INFO.SUCCESS]: (state, { id, result }) => ({
-      ...state,
-      infos: {
-        ...state.entities,
-        [id]: result.chapterInfo
-      }
-    }),
     [SET_CURRENT.ACTION]: (state, { current }) => ({
       ...state,
       current

--- a/src/redux/reducers/index.js
+++ b/src/redux/reducers/index.js
@@ -2,6 +2,7 @@ import { combineReducers } from 'redux';
 import { routerReducer } from 'react-router-redux';
 
 import chapters from './chapters';
+import chapterInfos from './chapterInfos';
 import verses from './verses';
 import audioplayer from './audioplayer';
 import lines from './lines';
@@ -13,15 +14,16 @@ import media from './media';
 import juzs from './juzs';
 
 export default combineReducers({
-  routing: routerReducer,
-  media,
-  chapters,
-  verses,
   audioplayer,
+  chapterInfos,
+  chapters,
   fontFaces,
+  juzs,
   lines,
+  media,
+  options,
+  routing: routerReducer,
   searchResults,
   suggestResults,
-  options,
-  juzs
+  verses
 });

--- a/src/routes.js
+++ b/src/routes.js
@@ -92,6 +92,7 @@ export const routes = [
     ),
     loadData: [
       ({ store: { dispatch }, location }) => {
+        console.log(location);
         if (__CLIENT__) {
           dispatch(search(location.query || location.q));
           return false;
@@ -100,13 +101,6 @@ export const routes = [
         return dispatch(search(location.query || location.q));
       }
     ]
-  },
-  {
-    path: '/:chapterId/info/:language?',
-    component: loadable(() =>
-      import(/* webpackChunkName: "ChapterInfo" */ './containers/ChapterInfo')
-    ),
-    loadData: [chaptersConnect, chapterInfoConnect]
   },
   {
     path: '/ayatul-kursi',
@@ -124,6 +118,13 @@ export const routes = [
           }
         })
     ]
+  },
+  {
+    path: '/:chapterId/info/:language?',
+    component: loadable(() =>
+      import(/* webpackChunkName: "ChapterInfo" */ './containers/ChapterInfo')
+    ),
+    loadData: [chaptersConnect, chapterInfoConnect]
   },
   {
     path: '/:chapterId(\\d+)/:range/tafsirs/:tafsirId',

--- a/src/routes.js
+++ b/src/routes.js
@@ -157,4 +157,46 @@ const routes = [
 export const getMatchedRoute = url =>
   routes.find(route => matchPath(url, route));
 
+export const checkOnEnterResult = (url) => {
+  const matchedRoute = getMatchedRoute(url);
+  const match = matchPath(url, matchedRoute);
+
+  if (matchedRoute && matchedRoute.onEnter) {
+    const result = matchedRoute.onEnter({
+      match,
+      params: match.params,
+      location: {
+        pathname: url
+      }
+    });
+
+    if (result) {
+      return result;
+    }
+  }
+
+  return null;
+};
+
+export const getPromises = (url, store) => {
+  const matchedRoute = getMatchedRoute(url);
+  const match = matchPath(url, matchedRoute);
+  const promises = [];
+
+  if (matchedRoute && matchedRoute.loadData) {
+    matchedRoute.loadData.forEach((connector) => {
+      promises.push(
+        connector({
+          store,
+          match,
+          params: match.params,
+          location: match.location
+        })
+      );
+    });
+  }
+
+  return promises;
+};
+
 export default routes;

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,10 +1,7 @@
-import React from 'react';
-import PropTypes from 'prop-types';
 import loadable from 'loadable-components';
-import { Switch, Route } from 'react-router';
+import { matchPath } from 'react-router';
 
 import Home from './containers/Home';
-import NotFound from './components/NotFound';
 
 import {
   chaptersConnect,
@@ -14,19 +11,9 @@ import {
   juzsConnect
 } from './containers/Surah/connect';
 import { search } from './redux/actions/search.js';
-import routePromises from './utils/routePromises';
 import validators from './utils/routeFilters';
 
-const GlobalNav = loadable(() =>
-  import(/* webpackChunkName: "GlobalNav" */ 'components/GlobalNav')
-);
-
-const defaultSetContext = context => ({
-  ...context,
-  status: 200
-});
-
-export const routes = [
+const routes = [
   {
     path: '/',
     exact: true,
@@ -92,7 +79,6 @@ export const routes = [
     ),
     loadData: [
       ({ store: { dispatch }, location }) => {
-        console.log(location);
         if (__CLIENT__) {
           dispatch(search(location.query || location.q));
           return false;
@@ -168,57 +154,7 @@ export const routes = [
   }
 ];
 
-const Routes = ({ store }) => (
-  <Switch>
-    {routes.map(({ component: Component, loadData, setContext, ...route }) => (
-      <Route
-        key={route.path}
-        {...route}
-        render={({ staticContext, ...routeProps }) => {
-          if (staticContext) {
-            const contextFunction = setContext || defaultSetContext;
+export const getMatchedRoute = url =>
+  routes.find(route => matchPath(url, route));
 
-            Object.assign(staticContext, contextFunction(staticContext));
-          }
-
-          if (__CLIENT__) {
-            routePromises({
-              store,
-              match: routeProps.match,
-              loadData
-            }).then(() => <Component {...routeProps} />);
-          }
-
-          return <Component {...routeProps} />;
-        }}
-      />
-    ))}{' '}
-    <Route component={NotFound} />
-  </Switch>
-);
-
-// eslint-disable-next-line no-unused-vars, react/prop-types
-export const Navbars = ({ match, ...props }) => (
-  <Switch>
-    {' '}
-    {routes
-      .filter(route => route.navbar)
-      // eslint-disable-next-line no-unused-vars
-      .map(({ navbar: Navbar, component, ...route }) => (
-        <Route
-          key={route.path}
-          {...route}
-          render={routeProps => <Navbar {...routeProps} {...props} />}
-        />
-      ))}{' '}
-    <Route
-      render={routeProps => <GlobalNav {...routeProps} {...props} isStatic />}
-    />{' '}
-  </Switch>
-);
-
-Routes.propTypes = {
-  store: PropTypes.object.isRequired // eslint-disable-line
-};
-
-export default Routes;
+export default routes;

--- a/src/server.js
+++ b/src/server.js
@@ -62,6 +62,7 @@ server.use((req, res) => {
   store.dispatch(setOption(cookie.load('options') || {}));
   debug('Server', 'Executing navigate action');
 
+  console.log('req.url', req.url);
   routes.forEach((route) => {
     const match = matchPath(req.url, route);
 
@@ -73,6 +74,8 @@ server.use((req, res) => {
           pathname: req.url
         }
       });
+      console.log('result', result);
+      console.log('match', match);
 
       if (result) {
         return res.status(result.status).redirect(result.url);

--- a/src/server.js
+++ b/src/server.js
@@ -62,30 +62,23 @@ server.use((req, res) => {
   store.dispatch(setOption(cookie.load('options') || {}));
   debug('Server', 'Executing navigate action');
 
-  console.log('req.url', req.url);
-  routes.forEach((route) => {
-    const match = matchPath(req.url, route);
+  const matchedRoute = routes.find(route => matchPath(req.url, route));
 
-    if (match && route.onEnter) {
-      const result = route.onEnter({
-        match,
-        params: match.params,
-        location: {
-          pathname: req.url
-        }
-      });
-      console.log('result', result);
-      console.log('match', match);
+  if (matchedRoute && matchedRoute.onEnter) {
+    const match = matchPath(req.url, matchedRoute);
 
-      if (result) {
-        return res.status(result.status).redirect(result.url);
+    const result = matchedRoute.onEnter({
+      match,
+      params: match.params,
+      location: {
+        pathname: req.url
       }
+    });
 
-      return null;
+    if (result) {
+      return res.status(result.status).redirect(result.url);
     }
-
-    return null;
-  });
+  }
 
   // inside a request
   const promises = [];

--- a/src/server.js
+++ b/src/server.js
@@ -63,10 +63,9 @@ server.use((req, res) => {
   debug('Server', 'Executing navigate action');
 
   const matchedRoute = routes.find(route => matchPath(req.url, route));
+  const match = matchPath(req.url, matchedRoute);
 
   if (matchedRoute && matchedRoute.onEnter) {
-    const match = matchPath(req.url, matchedRoute);
-
     const result = matchedRoute.onEnter({
       match,
       params: match.params,
@@ -82,26 +81,19 @@ server.use((req, res) => {
 
   // inside a request
   const promises = [];
-  // use `some` to imitate `<Switch>` behavior of selecting only
-  // the first to match
-  routes.some((route) => {
-    // use `matchPath` here
-    const match = matchPath(req.url, route);
-    if (match && route.loadData) {
-      route.loadData.forEach((connector) => {
-        promises.push(
-          connector({
-            store,
-            match,
-            params: match.params,
-            location: match.location
-          })
-        );
-      });
-    }
 
-    return match;
-  });
+  if (matchedRoute && matchedRoute.loadData) {
+    matchedRoute.loadData.forEach((connector) => {
+      promises.push(
+        connector({
+          store,
+          match,
+          params: match.params,
+          location: match.location
+        })
+      );
+    });
+  }
 
   Promise.all(promises).then(() => {
     const component = (

--- a/src/server.js
+++ b/src/server.js
@@ -15,7 +15,7 @@ import { getLoadableState } from 'loadable-components/server';
 
 import config from 'config';
 import expressConfig from './server/config/express';
-import { routes } from './routes';
+import { getMatchedRoute } from './routes';
 import ApiClient from './helpers/ApiClient';
 import createStore from './redux/create';
 import debug from './helpers/debug';
@@ -62,7 +62,7 @@ server.use((req, res) => {
   store.dispatch(setOption(cookie.load('options') || {}));
   debug('Server', 'Executing navigate action');
 
-  const matchedRoute = routes.find(route => matchPath(req.url, route));
+  const matchedRoute = getMatchedRoute(req.url);
   const match = matchPath(req.url, matchedRoute);
 
   if (matchedRoute && matchedRoute.onEnter) {

--- a/tests/__mocks__/fileMock.js
+++ b/tests/__mocks__/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = 'test-file-stub';

--- a/tests/fixtures/chapterInfos.js
+++ b/tests/fixtures/chapterInfos.js
@@ -1,0 +1,8 @@
+// eslint-disable-next-line import/prefer-default-export
+export const chapterInfo = {
+  source: 'source',
+  text: 'text',
+  shortText: 'shortText',
+  languageName: 'english',
+  chapterId: 1
+};

--- a/tests/fixtures/chapters.js
+++ b/tests/fixtures/chapters.js
@@ -11,7 +11,8 @@ export const chapter = {
   translatedName: {
     languageName: 'english',
     name: 'The Opener'
-  }
+  },
+  pages: [1, 2]
 };
 
 export const chapter2 = {

--- a/tests/routes.test.js
+++ b/tests/routes.test.js
@@ -1,0 +1,50 @@
+import {
+  getPromises,
+  getMatchedRoute,
+  checkOnEnterResult
+} from '../src/routes';
+
+const store = {
+  getState: () => ({
+    chapters: {
+      entities: {}
+    },
+    verses: {
+      entities: {}
+    }
+  }),
+  dispatch: jest.fn()
+};
+
+describe('routes', () => {
+  describe('#getPromises', () => {
+    test('should return promises when route contains loadData field', () => {
+      expect(getPromises('/1', store)).not.toHaveLength(0);
+    });
+
+    test('should not return promises when route does not contain loadData field', () => {
+      expect(getPromises('/contact', store)).toHaveLength(0);
+    });
+  });
+
+  describe('#getMatchedRoute', () => {
+    test('should return a matched route when it matches', () => {
+      expect(getMatchedRoute('/1')).toBeTruthy();
+    });
+
+    test('should not return a matched route when it matches', () => {
+      expect(getMatchedRoute('/not-here')).toBeUndefined();
+    });
+  });
+
+  describe('#checkOnEnterResult', () => {
+    test('should not return a result', () => {
+      expect(checkOnEnterResult('/1')).toBeNull();
+      expect(checkOnEnterResult('/not-here')).toBeNull();
+    });
+
+    test('should return a result', () => {
+      expect(checkOnEnterResult('/1/100')).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
### Title of change
In an effort to move more things outside of the giant Surah component, components down the street should pull data from Redux that they require instead of having a top-level component that passes data deep down the tree.

The first for this is the surah info panel. 


### Checklist

- [x] Unit tests written
- [x] Manually tested
- [x] Prettier & ESLint were run
- [x] New dependencies are included in `package-lock.json`

### Screenshot
_insert screenshot if needed_
