### PR TITLE
Remove babel-typecheck

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,11 +7,6 @@
     ["system-import-transformer", {"modules": "common"}]
   ],
   "env": {
-    "development": {
-      "plugins": [
-        "typecheck"
-      ]
-    },
     "production": {
       "plugins": [
         "transform-react-inline-elements",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3536,14 +3536,6 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.8.3.tgz",
       "integrity": "sha512-goYwp8dMrzHD6x9GjZ2M85Mk2vxf1h85CnUgAjfftUnlJvzF4uj5MrbReHBTbjQ96C8CuRzvhYZ3tv8H3Sc1ZA=="
     },
-    "babel-plugin-typecheck": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-typecheck/-/babel-plugin-typecheck-3.9.0.tgz",
-      "integrity": "sha1-DtrHVzriTuWMb5Exn1dLxRJLDw8=",
-      "requires": {
-        "babel-generator": "6.26.0"
-      }
-    },
     "babel-plugin-undeclared-variables-check": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "babel-plugin-transform-react-inline-elements": "6.8.0",
     "babel-plugin-transform-react-remove-prop-types": "0.2.11",
     "babel-plugin-transform-runtime": "6.12.0",
-    "babel-plugin-typecheck": "3.9.0",
     "babel-polyfill": "6.13.0",
     "babel-preset-es2015": "^6.24.0",
     "babel-preset-react": "6.11.1",

--- a/src/containers/ChapterInfo/index.js
+++ b/src/containers/ChapterInfo/index.js
@@ -70,7 +70,7 @@ ChapterInfo.propTypes = {
 
 function mapStateToProps(state, ownProps) {
   const chapterId = parseInt(ownProps.match.params.chapterId, 10);
-  const chapter: Object = state.chapters.entities[chapterId];
+  const chapter = state.chapters.entities[chapterId];
 
   return {
     chapter,

--- a/src/containers/Surah/index.js
+++ b/src/containers/Surah/index.js
@@ -495,8 +495,8 @@ Surah.propTypes = {
 
 function mapStateToProps(state, ownProps) {
   const chapterId = parseInt(ownProps.match.params.chapterId, 10);
-  const chapter: Object = state.chapters.entities[chapterId];
-  const verses: Object = state.verses.entities[chapterId];
+  const chapter = state.chapters.entities[chapterId];
+  const verses = state.verses.entities[chapterId];
   const verseArray = verses
     ? Object.keys(verses).map(key => parseInt(key.split(':')[1], 10))
     : [];

--- a/src/containers/VerseTafsir/index.js
+++ b/src/containers/VerseTafsir/index.js
@@ -81,7 +81,7 @@ function mapStateToProps(state, ownProps) {
   }`;
   const chapterId = parseInt(ownProps.match.params.chapterId, 10);
   const tafsirId = ownProps.match.params.tafsirId;
-  const verse: Object = state.verses.entities[chapterId][verseKey];
+  const verse = state.verses.entities[chapterId][verseKey];
 
   return {
     verse,

--- a/webpack/dev.config.js
+++ b/webpack/dev.config.js
@@ -66,9 +66,7 @@ module.exports = {
               plugins: [
                 'react-hot-loader/babel',
                 'transform-runtime',
-                // 'add-module-exports',
                 'transform-react-display-name',
-                'typecheck',
                 'react-hot-loader/babel',
                 'syntax-dynamic-import'
               ],


### PR DESCRIPTION
### Title of change
Remove babel-typecheck. If we want to do typecheck, then we should explore typescript or flowtype. This package has not been updated in 2 years.


### Checklist

- [ ] Unit tests written
- [ ] Manually tested
- [x] Prettier & ESLint were run
- [x] New dependencies are included in `package-lock.json`

### Screenshot
_insert screenshot if needed_
