### PR TITLE
Changed the link of Ayatul Kursi

### DIFF
--- a/src/components/Home/QuickChapters/index.js
+++ b/src/components/Home/QuickChapters/index.js
@@ -69,9 +69,9 @@ export default () => (
       </Span>
       <Span>
         <Link
-          to="/ayatul-kursi"
+          to="/2/255"
           {...QUICK_LINKS_EVENTS.CLICK.VERSE.PROPS}
-          data-metrics-verse-key="2:225"
+          data-metrics-verse-key="2:255"
         >
           Ayatul Kursi
         </Link>


### PR DESCRIPTION
### Title of change
I have changed the link of Ayatul Kursi in quicklinks on homepage, because https://quran.com/ayatul-kursi gave an internal server error. 

### Checklist

- [ ] Unit tests written
- [X] Manually tested
- [ ] Prettier & ESLint were run
- [ ] New dependencies are included in `package-lock.json`
