### PR TITLE
Remove CSS prefix from styled components

### DIFF
--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -42,10 +42,6 @@ const List = styled.ul`
 const StyledLink = styled.a`
   font-size: 13px;
   color: rgba(255, 255, 255, 0.5);
-  -webkit-transition: color 0.15s ease-in-out;
-  -moz-transition: color 0.15s ease-in-out;
-  -o-transition: color 0.15s ease-in-out;
-  -ms-transition: color 0.15s ease-in-out;
   transition: color 0.15s ease-in-out;
 
   &:hover {
@@ -56,10 +52,6 @@ const StyledLink = styled.a`
 const StyledRouterLink = styled(Link)`
   font-size: 13px;
   color: rgba(255, 255, 255, 0.5);
-  -webkit-transition: color 0.15s ease-in-out;
-  -moz-transition: color 0.15s ease-in-out;
-  -o-transition: color 0.15s ease-in-out;
-  -ms-transition: color 0.15s ease-in-out;
   transition: color 0.15s ease-in-out;
 
   &:hover {


### PR DESCRIPTION
### Title of change
Remove CSS prefix from styled components, because the CSS rules in Styled Components are automatically vendor prefixed.
Fixes #947

### Checklist

- [ ] ~Unit tests written~
- [x] Manually tested
- [x] Prettier & ESLint were run
- [ ] ~New dependencies are included in `package-lock.json`~

### Screenshot
N/A
