### PR TITLE
Ensure suggestions is an array and close autocomplete on search

### DIFF
--- a/src/components/SearchAutocomplete.tsx
+++ b/src/components/SearchAutocomplete.tsx
@@ -223,11 +223,14 @@ class SearchAutocomplete extends Component<Props & typeof defaultProps> {
   };
 
   render() {
+    const suggestions = this.getSuggestions();
+    const hasSuggestions = !!suggestions.length;
+
     return (
-      <Container className={this.getSuggestions().length ? '' : 'hidden'}>
+      <Container className={hasSuggestions ? '' : 'hidden'}>
         <List role="menu">
-          {!!this.getSuggestions().length &&
-            this.getSuggestions().map((item: SuggestionShape) => (
+          {hasSuggestions &&
+            suggestions.map((item: SuggestionShape) => (
               <li key={item.href}>
                 <StyledLink>
                   <a href={item.href}>{item.ayah}</a>

--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -131,6 +131,8 @@ class SearchInput extends Component<Props> {
       label: value,
     });
 
+    this.handleHideAutocomplete();
+
     return push(`/search?q=${value}`);
   };
 

--- a/src/redux/reducers/suggest.ts
+++ b/src/redux/reducers/suggest.ts
@@ -31,7 +31,9 @@ export default (state = INITIAL_STATE, action: $TsFixMe) => {
           ...prevState,
           results: {
             ...state.results,
-            [action.meta.query]: camelcaseKeys(action.payload, { deep: true }),
+            [action.meta.query]: Array.isArray(action.payload)
+              ? camelcaseKeys(action.payload, { deep: true })
+              : [],
           },
         }),
       });


### PR DESCRIPTION
### Ensure suggestions is an array and close autocomplete on search
When a search yields no suggestions the backend will produce a malformed response in the form `{"": []}` (given that the structure should be `[{...result...}, ...]`), which causes the front-end to choke. This cleans that up to ensure we always put an array into the redux store.

Also closes the autocomplete when a search is initiated as a small quality-of-life improvement to the search experience.

### Checklist

- [ ] Unit tests written
- [ ] Manually tested
- [ ] Prettier & ESLint were run
- [ ] New dependencies are included in `package-lock.json`

