### PR TITLE
Ensure camelcaseKeys is never passed a non-object

### DIFF
--- a/src/redux/reducers/audioplayer.ts
+++ b/src/redux/reducers/audioplayer.ts
@@ -52,7 +52,9 @@ export default (state = INITIAL_STATE, action: $TsFixMe) => {
     case FETCH_AUDIOPLAYER: {
       return handle(state, action, {
         success: prevState => {
-          const audioFile: $TsFixMe = camelcaseKeys(action.payload.audio_file);
+          const audioFile: $TsFixMe = camelcaseKeys(
+            action.payload.audio_file || {}
+          );
 
           return {
             ...prevState,

--- a/src/redux/reducers/chapterInfos.ts
+++ b/src/redux/reducers/chapterInfos.ts
@@ -32,7 +32,9 @@ export default (state = INITIAL_STATE, action: $TsFixMe) => {
           ...prevState,
           entities: {
             ...state.entities,
-            [action.meta.chapterId]: camelcaseKeys(action.payload.chapter_info),
+            [action.meta.chapterId]: camelcaseKeys(
+              action.payload.chapter_info || {}
+            ),
           },
         }),
       });

--- a/src/redux/reducers/chapters.ts
+++ b/src/redux/reducers/chapters.ts
@@ -34,7 +34,7 @@ export default (state = INITIAL_STATE, action: $TsFixMe) => {
           entities: {
             ...prevState.entities,
             ...keyBy(
-              camelcaseKeys(action.payload.chapters, { deep: true }),
+              camelcaseKeys(action.payload.chapters || {}, { deep: true }),
               'id'
             ),
           },

--- a/src/redux/reducers/footNotes.ts
+++ b/src/redux/reducers/footNotes.ts
@@ -29,7 +29,9 @@ export default (state = INITIAL_STATE, action: $TsFixMe) => {
           ...prevState,
           entities: {
             ...prevState.entities,
-            [action.meta.verseKey]: camelcaseKeys(action.payload.foot_note),
+            [action.meta.verseKey]: camelcaseKeys(
+              action.payload.foot_note || {}
+            ),
           },
         }),
       });

--- a/src/redux/reducers/juzs.ts
+++ b/src/redux/reducers/juzs.ts
@@ -33,7 +33,10 @@ export default (state = INITIAL_STATE, action: $TsFixMe) => {
           ...prevState,
           entities: {
             ...state.entities,
-            ...keyBy(camelcaseKeys(action.payload.juzs, { deep: true }), 'id'),
+            ...keyBy(
+              camelcaseKeys(action.payload.juzs || {}, { deep: true }),
+              'id'
+            ),
           },
         }),
       });

--- a/src/redux/reducers/options.ts
+++ b/src/redux/reducers/options.ts
@@ -40,7 +40,7 @@ export default (state = INITIAL_STATE, action: $TsFixMe) => {
         success: prevState => ({
           ...prevState,
           recitations: action.payload.recitations.map((obj: $TsFixMe) =>
-            camelcaseKeys(obj)
+            camelcaseKeys(obj || {})
           ),
         }),
       });
@@ -58,7 +58,7 @@ export default (state = INITIAL_STATE, action: $TsFixMe) => {
         success: prevState => ({
           ...prevState,
           translations: action.payload.translations.map((obj: $TsFixMe) =>
-            camelcaseKeys(obj)
+            camelcaseKeys(obj || {})
           ),
         }),
       });
@@ -76,7 +76,7 @@ export default (state = INITIAL_STATE, action: $TsFixMe) => {
         success: prevState => ({
           ...prevState,
           tafsirs: action.payload.tafsirs.map((obj: $TsFixMe) =>
-            camelcaseKeys(obj)
+            camelcaseKeys(obj || {})
           ),
         }),
       });

--- a/src/redux/reducers/search.ts
+++ b/src/redux/reducers/search.ts
@@ -49,7 +49,7 @@ export default (state = INITIAL_STATE, action: $TsFixMe) => {
           perPage: action.payload.per_page,
           took: action.payload.took,
           query: action.payload.query,
-          entities: camelcaseKeys(action.payload.results),
+          entities: camelcaseKeys(action.payload.results || {}),
         }),
       });
     }

--- a/src/redux/reducers/suggest.ts
+++ b/src/redux/reducers/suggest.ts
@@ -31,7 +31,9 @@ export default (state = INITIAL_STATE, action: $TsFixMe) => {
           ...prevState,
           results: {
             ...state.results,
-            [action.meta.query]: camelcaseKeys(action.payload, { deep: true }),
+            [action.meta.query]: camelcaseKeys(action.payload || {}, {
+              deep: true,
+            }),
           },
         }),
       });

--- a/src/redux/reducers/verses.ts
+++ b/src/redux/reducers/verses.ts
@@ -36,7 +36,7 @@ export default (state = INITIAL_STATE, action: $TsFixMe) => {
             [action.meta.chapterId]: {
               ...state.entities[action.meta.chapterId],
               ...keyBy(
-                camelcaseKeys(action.payload.verses, { deep: true }),
+                camelcaseKeys(action.payload.verses || {}, { deep: true }),
                 'verseKey'
               ),
             },


### PR DESCRIPTION
### Ensure camelcaseKeys is never passed a non-object

Currently, the `/api/v3/juzs` endpoint is 500ing, which causes `camelcaseKeys` to be called with `undefined`. According to https://github.com/sindresorhus/camelcase-keys/issues/15, we should ensure we never call `camelcaseKeys` with something other than an object. Ideally, this is fixed on the BE where we fix the issue that is causing the BE to 500 but this will at least ensure the FE does not completely break and hang.

I suspect this is also the reason why the homepage of the staging site is hanging (http://staging.quran.com/).

### Checklist

- [ ] Unit tests written
- [ x ] Manually tested
- [ x ] Prettier & ESLint were run
- [ ] New dependencies are included in `package-lock.json`
