### PR TITLE
Fix juz object Object Tooltip Text

### DIFF
--- a/src/components/JuzDecoration.tsx
+++ b/src/components/JuzDecoration.tsx
@@ -51,7 +51,7 @@ const JuzDecoration: React.SFC<Props> = ({ juzNumber }: Props) => (
         {JUZ_AND_HIZB_ARABIC_NUMBERS[juzNumber * 2 - 1]}
       </StyledJuzNumber>
     </StyledContainer>
-    <StyledJuzArt src={juzMarkBottom} alt="juz top Art" />
+    <StyledJuzArt src={juzMarkBottom} alt="juz bottom Art" />
   </Fragment>
 );
 

--- a/src/components/JuzMarker.tsx
+++ b/src/components/JuzMarker.tsx
@@ -5,7 +5,6 @@ import { Tooltip } from 'react-tippy';
 import { JUZ_START } from '../constants';
 import JuzDecoration from './JuzDecoration';
 import { VerseShape } from '../shapes';
-import T, { KEYS } from './T';
 
 const StyledAyah = styled.div`
   margin-top: 3%;
@@ -29,15 +28,7 @@ export const JuzMarker: React.SFC<Props> = ({
     return (
       <Fragment>
         <b className="col-xs-1">
-          <Tooltip
-            arrow
-            title={
-              <T
-                id={KEYS.JUZ_INDEX_HEADING}
-                values={{ juzNumber: `${juzNumber}` }}
-              />
-            }
-          >
+          <Tooltip arrow title={`Juz #${juzNumber}`}>
             <JuzDecoration juzNumber={juzNumber} />
           </Tooltip>
         </b>


### PR DESCRIPTION
### Title of change
The Juz tooltip was broken showing `object Object` instead of the Juz number.

### Checklist

- [ ] Unit tests written
- [x] Manually tested
- [x] Prettier & ESLint were run (TSLint was not able to clean entirely. Too many errors still.)
- [ ] New dependencies are included in `package-lock.json`

### Screenshot
**Before**

![image](https://user-images.githubusercontent.com/23035000/50580961-f692bf00-0e22-11e9-8439-f5ba1cae6d32.png)

**After**

![image](https://user-images.githubusercontent.com/23035000/50580942-d6630000-0e22-11e9-92d1-644754561f05.png)

