### PR TITLE
Share icons to be inline

### DIFF
--- a/src/components/Share.tsx
+++ b/src/components/Share.tsx
@@ -29,7 +29,7 @@ const Container = styled.div<{ inline?: boolean }>`
 const FacebookButton = styled(FacebookShareButton)`
   background-repeat: no-repeat;
   background-size: 12px;
-  padding-top: 1px;
+  padding: 1px 5px 0px 0px;
 `;
 
 const TwitterButton = styled(TwitterShareButton)`

--- a/src/components/verse/Controls.tsx
+++ b/src/components/verse/Controls.tsx
@@ -105,7 +105,7 @@ const Controls: React.SFC<Props> = ({
       <i className="ss-book vertical-align-middle" />{' '}
       <T id={KEYS.ACTIONS_TAFSIRS} />
     </ButtonLink>
-    {!isSearched && !isPdf && <Share chapter={chapter} verse={verse} />}
+    {!isSearched && !isPdf && <Share chapter={chapter} verse={verse} inline />}
   </ControlsNode>
 );
 


### PR DESCRIPTION
### Title of change
This PR should make the Facebook and Twitter icons inline so that it looks much better.

### Checklist

- [ ] Unit tests written
- [x] Manually tested
- [x] Prettier & ESLint were run
- [ ] New dependencies are included in `package-lock.json`

### Screenshot

**Before**

![image](https://user-images.githubusercontent.com/23035000/50581143-d95ef000-0e24-11e9-98dd-9e7dda166d07.png)


**After**

![image](https://user-images.githubusercontent.com/23035000/50581198-699d3500-0e25-11e9-95ba-3b893b47085b.png)



