### PR TITLE
Update flow of remove-all-translations feature 

### DIFF
--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -11,7 +11,7 @@ import ReciterDropdownContainer from '../containers/settings/ReciterDropdownCont
 import TranslationsDropdownContainer from '../containers/settings/TranslationsDropdownContainer';
 import TooltipOptions from './settings/TooltipOptions';
 import { VerseShape, ChapterShape, SettingsShape } from '../shapes';
-import { SetSetting } from '../redux/actions/settings';
+import { SetSetting, SetSettingPayload } from '../redux/actions/settings';
 import { FetchVerses } from '../redux/actions/verses';
 
 const propTypes = {
@@ -35,7 +35,7 @@ type Props = {
 class Settings extends Component<Props> {
   static propTypes = propTypes;
 
-  handleSettingChange = (payload: $TsFixMe) => {
+  handleSettingChange = (payload: SetSettingPayload) => {
     const { chapter, setSetting, settings, fetchVerses, verses } = this.props;
 
     setSetting(payload);
@@ -50,8 +50,7 @@ class Settings extends Component<Props> {
         chapter.chapterNumber,
         paging,
         {
-          ...settings,
-          ...payload,
+          translations: payload.translations || settings.translations,
         },
         settings
       );
@@ -77,7 +76,7 @@ class Settings extends Component<Props> {
         />
         <hr />
         <ReciterDropdownContainer />
-        <TranslationsDropdownContainer />
+        <TranslationsDropdownContainer setSetting={this.handleSettingChange} />
         <TooltipOptions tooltip={settings.tooltip} onChange={setSetting} />
         <hr />
         <FontSizeOptions fontSize={settings.fontSize} onChange={setSetting} />

--- a/src/components/settings/TranslationsDropdown.tsx
+++ b/src/components/settings/TranslationsDropdown.tsx
@@ -4,7 +4,7 @@ import Menu, { MenuItem } from 'quran-components/lib/Menu';
 import Checkbox from 'quran-components/lib/Checkbox';
 import Icon from 'quran-components/lib/Icon';
 import T, { KEYS } from '../T';
-import { SetSetting } from '../../redux/actions/settings';
+import { SetSetting, SetSettingPayload } from '../../redux/actions/settings';
 import { TranslationShape } from '../../shapes';
 import { FetchTranslations } from '../../redux/actions/options';
 
@@ -40,7 +40,7 @@ const defaultProps: { translationOptions: Array<TranslationShape> } = {
 };
 
 type Props = {
-  setSetting: SetSetting;
+  setSetting: (payload: SetSettingPayload) => void;
   translationOptions: Array<TranslationShape>;
   translationSettings: Array<number>;
   fetchTranslations: FetchTranslations;
@@ -81,7 +81,7 @@ class TranslationsDropdown extends Component<Props> {
     items: Array<TranslationShape>,
     render: (translation: TranslationShape) => string
   ) {
-    const { translationSettings, translationOptions } = this.props;
+    const { translationSettings } = this.props;
 
     return items.map(translationOption => {
       const checked = translationSettings.find(
@@ -97,7 +97,7 @@ class TranslationsDropdown extends Component<Props> {
             checked={checked || false}
             disabled={
               !checked &&
-              translationOptions.length >= TRANSLATIONS_SELECTION_LIMIT
+              translationSettings.length >= TRANSLATIONS_SELECTION_LIMIT
             }
             handleChange={() => this.handleOptionSelected(translationOption.id)}
           >
@@ -136,14 +136,17 @@ class TranslationsDropdown extends Component<Props> {
   }
 
   render() {
+    const { translationSettings } = this.props;
     return (
       <MenuItem
         icon={<Icon type="list" />}
         menu={
           <Menu>
-            <MenuItem onClick={this.handleRemoveContent}>
-              <T id={KEYS.SETTING_TRANSLATIONS_REMOVEALL} />
-            </MenuItem>
+            {translationSettings.length > 0 && (
+              <MenuItem onClick={this.handleRemoveContent}>
+                <T id={KEYS.SETTING_TRANSLATIONS_REMOVEALL} />
+              </MenuItem>
+            )}
 
             <MenuItem divider>
               <T id={KEYS.SETTING_TRANSLATIONS_ENGLISH} />

--- a/src/containers/settings/TranslationsDropdownContainer.tsx
+++ b/src/containers/settings/TranslationsDropdownContainer.tsx
@@ -11,5 +11,5 @@ export const mapStateToProps = (state: ReduxState) => ({
 
 export default connect(
   mapStateToProps,
-  { fetchTranslations, setSetting }
+  { fetchTranslations }
 )(TranslationsDropdown);

--- a/src/redux/actions/settings.ts
+++ b/src/redux/actions/settings.ts
@@ -18,6 +18,8 @@ type Payload = {
   isNightMode?: boolean;
 };
 
+export type SetSettingPayload = Payload;
+
 export const setSetting = (payload: Payload) => {
   const options = cookie.load(COOKIE_SETTINGS_KEY) || {}; // protect against first timers.
 

--- a/src/redux/actions/verses.ts
+++ b/src/redux/actions/verses.ts
@@ -9,7 +9,7 @@ type Params = {
 };
 
 const prepareParams = (params: any, options: any) => {
-  if (params.translations && params.translations.length) {
+  if (params.translations && Array.isArray(params.translations)) {
     const translations =
       typeof params.translations === 'string'
         ? params.translations.split(',')


### PR DESCRIPTION
### Title of change
Issue #862

### Checklist

- [ v] Manually tested
- [ v] Prettier & ESLint were run

I guess if my interpretation is right, this will remove all translations from verses when "Remove all" options is clicked.
I also added a logic that hides "Remove all" option when no option selected