### PR TITLE
Add dynamic og:image and remove canonical urls

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -8,15 +8,14 @@ const environment = {
 }[process.env.NODE_ENV || 'development'];
 
 const title = "Al-Qur'an al-Kareem - القرآن الكريم";
-const description =
-  'The Quran translated into many languages in a simple and easy interface.';
+const description = 'The Quran translated into many languages in a simple and easy interface.';
 const keywords = [
   'القران الكريم',
   'قران كريم',
   'القرآن',
   'قران',
   'quran',
-  "qur'an",
+  'qur\'an',
   'koran',
   'kareem',
   'surah',
@@ -86,8 +85,7 @@ const config = {
         },
         {
           name: 'viewport',
-          content:
-            'width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no'
+          content: 'width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no'
         },
         {
           name: 'google-site-verification',
@@ -306,8 +304,7 @@ const config = {
       /* SEO: https://developers.google.com/structured-data/site-name#markup_requirements */
       script: [
         {
-          src:
-            'https://cdn.polyfill.io/v2/polyfill.min.js?features=Intl.~locale.en',
+          src: 'https://cdn.polyfill.io/v2/polyfill.min.js?features=Intl.~locale.en',
           async: '',
           defer: ''
         },

--- a/src/config.js
+++ b/src/config.js
@@ -8,14 +8,15 @@ const environment = {
 }[process.env.NODE_ENV || 'development'];
 
 const title = "Al-Qur'an al-Kareem - القرآن الكريم";
-const description = 'The Quran translated into many languages in a simple and easy interface.';
+const description =
+  'The Quran translated into many languages in a simple and easy interface.';
 const keywords = [
   'القران الكريم',
   'قران كريم',
   'القرآن',
   'قران',
   'quran',
-  'qur\'an',
+  "qur'an",
   'koran',
   'kareem',
   'surah',
@@ -85,7 +86,8 @@ const config = {
         },
         {
           name: 'viewport',
-          content: 'width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no'
+          content:
+            'width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no'
         },
         {
           name: 'google-site-verification',
@@ -116,16 +118,12 @@ const config = {
           content: description
         },
         {
-          property: 'og:url',
-          content: 'https://quran.com'
-        },
-        {
           property: 'og:type',
           content: 'website'
         },
         {
           name: 'twitter:card',
-          content: 'summary'
+          content: 'summary_large_image'
         },
         {
           name: 'twitter:title',
@@ -138,14 +136,6 @@ const config = {
         {
           name: 'twitter:image',
           content: 'https://quran.com/images/thumbnail.png'
-        },
-        {
-          name: 'twitter:image:width',
-          content: '200'
-        },
-        {
-          name: 'twitter:image:height',
-          content: '200'
         },
         {
           name: 'google-play-app',
@@ -316,7 +306,8 @@ const config = {
       /* SEO: https://developers.google.com/structured-data/site-name#markup_requirements */
       script: [
         {
-          src: 'https://cdn.polyfill.io/v2/polyfill.min.js?features=Intl.~locale.en',
+          src:
+            'https://cdn.polyfill.io/v2/polyfill.min.js?features=Intl.~locale.en',
           async: '',
           defer: ''
         },

--- a/src/containers/ChapterInfo/index.js
+++ b/src/containers/ChapterInfo/index.js
@@ -23,7 +23,7 @@ const ChapterInfo = ({ chapter, info }) => (
     <Helmet
       {...makeHeadTags({
         title: `Surah ${chapter.nameSimple} [${chapter.chapterNumber}]`,
-        image: `https://og.tarteel.io/${chapter.chapterNumber}`,
+        image: `https://quran-og-image.vercel.app/${chapter.chapterNumber}`,
         description: `${info ? info.shortText : ''} This Surah has ${chapter.versesCount} verses and resides between pages ${chapter.pages[0]} to ${chapter.pages[1]} in the Quran.` // eslint-disable-line max-len
       })}
       script={[

--- a/src/containers/ChapterInfo/index.js
+++ b/src/containers/ChapterInfo/index.js
@@ -18,16 +18,13 @@ const SurahInfo = Loadable({
   LoadingComponent: ComponentLoader
 });
 
-const ChapterInfo = ({ chapter, info }) =>
+const ChapterInfo = ({ chapter, info }) => (
   <div className="row" style={{ marginTop: 20 }}>
     <Helmet
       {...makeHeadTags({
         title: `Surah ${chapter.nameSimple} [${chapter.chapterNumber}]`,
         image: `https://og.tarteel.io/${chapter.chapterNumber}`,
-        description: `${info
-          ? info.shortText
-          : ''} This Surah has ${chapter.versesCount} verses and resides between pages ${chapter
-          .pages[0]} to ${chapter.pages[1]} in the Quran.` // eslint-disable-line max-len
+        description: `${info ? info.shortText : ''} This Surah has ${chapter.versesCount} verses and resides between pages ${chapter.pages[0]} to ${chapter.pages[1]} in the Quran.` // eslint-disable-line max-len
       })}
       script={[
         {
@@ -63,7 +60,8 @@ const ChapterInfo = ({ chapter, info }) =>
         />
       </Button>
     </div>
-  </div>;
+  </div>
+);
 
 ChapterInfo.propTypes = {
   chapter: customPropTypes.surahType,

--- a/src/containers/ChapterInfo/index.js
+++ b/src/containers/ChapterInfo/index.js
@@ -18,12 +18,16 @@ const SurahInfo = Loadable({
   LoadingComponent: ComponentLoader
 });
 
-const ChapterInfo = ({ chapter, info }) => (
+const ChapterInfo = ({ chapter, info }) =>
   <div className="row" style={{ marginTop: 20 }}>
     <Helmet
       {...makeHeadTags({
         title: `Surah ${chapter.nameSimple} [${chapter.chapterNumber}]`,
-        description: `${info ? info.shortText : ''} This Surah has ${chapter.versesCount} verses and resides between pages ${chapter.pages[0]} to ${chapter.pages[1]} in the Quran.` // eslint-disable-line max-len
+        image: `https://og.tarteel.io/${chapter.chapterNumber}`,
+        description: `${info
+          ? info.shortText
+          : ''} This Surah has ${chapter.versesCount} verses and resides between pages ${chapter
+          .pages[0]} to ${chapter.pages[1]} in the Quran.` // eslint-disable-line max-len
       })}
       script={[
         {
@@ -59,8 +63,7 @@ const ChapterInfo = ({ chapter, info }) => (
         />
       </Button>
     </div>
-  </div>
-);
+  </div>;
 
 ChapterInfo.propTypes = {
   chapter: customPropTypes.surahType,

--- a/src/containers/Surah/index.js
+++ b/src/containers/Surah/index.js
@@ -184,7 +184,7 @@ class Surah extends Component {
     const hasAyahNumber = params.range && !isNaN(params.range);
 
     if (hasAyahNumber) {
-      return `https://og.tarteel.io/${chapter.chapterNumber}/${params.ragne}`;
+      return `https://og.tarteel.io/${chapter.chapterNumber}/${params.range}`;
     }
 
     return `https://og.tarteel.io/${chapter.chapterNumber}`;
@@ -217,17 +217,13 @@ class Surah extends Component {
       const verse = verses[`${chapter.chapterNumber}:${params.range}`];
 
       if (verse && verse.content && verse.content[0]) {
-        return `Surat ${chapter.nameSimple} [verse ${params.range}] - ${verse
-          .content[0].text}`;
+        return `Surat ${chapter.nameSimple} [verse ${params.range}] - ${verse.content[0].text}`;
       }
 
       return `Surat ${chapter.nameSimple} [verse ${params.range}]`;
     }
 
-    return `${info
-      ? info.shortText
-      : ''} This Surah has ${chapter.versesCount} verses and resides between pages ${chapter
-      .pages[0]} to ${chapter.pages[1]} in the Quran.`; // eslint-disable-line max-len
+    return `${info ? info.shortText : ''} This Surah has ${chapter.versesCount} verses and resides between pages ${chapter.pages[0]} to ${chapter.pages[1]} in the Quran.`; // eslint-disable-line max-len
   }
 
   renderNoAyah() {
@@ -262,10 +258,9 @@ class Surah extends Component {
 
     // If single verse, eh. /2/30
     if (isSingleAyah) {
-      const to =
-        this.getFirst() + 10 > chapter.versesCount
-          ? chapter.versesCount
-          : this.getFirst() + 10;
+      const to = this.getFirst() + 10 > chapter.versesCount
+        ? chapter.versesCount
+        : this.getFirst() + 10;
       return (
         <ul className="pager">
           <li className="text-center">
@@ -292,8 +287,7 @@ class Surah extends Component {
             {chapter.chapterNumber > 1 &&
               <li className="previous">
                 <Link
-                  to={`/${chapter.chapterNumber * 1 -
-                    1}?translations=${translations}`}
+                  to={`/${chapter.chapterNumber * 1 - 1}?translations=${translations}`}
                 >
                   ←
                   <LocaleFormattedMessage
@@ -319,8 +313,7 @@ class Surah extends Component {
             {chapter.chapterNumber < 114 &&
               <li className="next">
                 <Link
-                  to={`/${chapter.chapterNumber * 1 +
-                    1}?translations=${translations}`}
+                  to={`/${chapter.chapterNumber * 1 + 1}?translations=${translations}`}
                 >
                   <LocaleFormattedMessage
                     id="chapter.next"
@@ -350,7 +343,7 @@ class Surah extends Component {
       currentVerse
     } = this.props; // eslint-disable-line no-shadow
 
-    return Object.values(verses).map(verse =>
+    return Object.values(verses).map(verse => (
       <Verse
         verse={verse}
         chapter={chapter}
@@ -367,7 +360,7 @@ class Surah extends Component {
         userAgent={options.userAgent}
         audio={options.audio}
       />
-    );
+    ));
   }
 
   renderLines() {
@@ -439,9 +432,7 @@ class Surah extends Component {
           ]}
           style={[
             {
-              cssText: `.text-arabic{font-size: ${options.fontSize
-                .arabic}rem;} .text-translation{font-size: ${options.fontSize
-                .translation}rem;}` // eslint-disable-line max-len
+              cssText: `.text-arabic{font-size: ${options.fontSize.arabic}rem;} .text-translation{font-size: ${options.fontSize.translation}rem;}` // eslint-disable-line max-len
             }
           ]}
         />

--- a/src/containers/Surah/index.js
+++ b/src/containers/Surah/index.js
@@ -178,6 +178,18 @@ class Surah extends Component {
     return `Surah ${chapter.nameSimple} [${chapter.chapterNumber}]`;
   }
 
+  // Generates the url for the open graph image
+  ogImage() {
+    const { params, chapter } = this.props;
+    const hasAyahNumber = params.range && !isNaN(params.range);
+
+    if (hasAyahNumber) {
+      return `https://og.tarteel.io/${chapter.chapterNumber}/${params.ragne}`;
+    }
+
+    return `https://og.tarteel.io/${chapter.chapterNumber}`;
+  }
+
   description() {
     const { params, verses, chapter, info } = this.props;
 
@@ -205,13 +217,17 @@ class Surah extends Component {
       const verse = verses[`${chapter.chapterNumber}:${params.range}`];
 
       if (verse && verse.content && verse.content[0]) {
-        return `Surat ${chapter.nameSimple} [verse ${params.range}] - ${verse.content[0].text}`;
+        return `Surat ${chapter.nameSimple} [verse ${params.range}] - ${verse
+          .content[0].text}`;
       }
 
       return `Surat ${chapter.nameSimple} [verse ${params.range}]`;
     }
 
-    return `${info ? info.shortText : ''} This Surah has ${chapter.versesCount} verses and resides between pages ${chapter.pages[0]} to ${chapter.pages[1]} in the Quran.`; // eslint-disable-line max-len
+    return `${info
+      ? info.shortText
+      : ''} This Surah has ${chapter.versesCount} verses and resides between pages ${chapter
+      .pages[0]} to ${chapter.pages[1]} in the Quran.`; // eslint-disable-line max-len
   }
 
   renderNoAyah() {
@@ -246,9 +262,10 @@ class Surah extends Component {
 
     // If single verse, eh. /2/30
     if (isSingleAyah) {
-      const to = this.getFirst() + 10 > chapter.versesCount
-        ? chapter.versesCount
-        : this.getFirst() + 10;
+      const to =
+        this.getFirst() + 10 > chapter.versesCount
+          ? chapter.versesCount
+          : this.getFirst() + 10;
 
       return (
         <ul className="pager">
@@ -276,7 +293,8 @@ class Surah extends Component {
             {chapter.chapterNumber > 1 &&
               <li className="previous">
                 <Link
-                  to={`/${chapter.chapterNumber * 1 - 1}?translations=${translations}`}
+                  to={`/${chapter.chapterNumber * 1 -
+                    1}?translations=${translations}`}
                 >
                   ←
                   <LocaleFormattedMessage
@@ -302,7 +320,8 @@ class Surah extends Component {
             {chapter.chapterNumber < 114 &&
               <li className="next">
                 <Link
-                  to={`/${chapter.chapterNumber * 1 + 1}?translations=${translations}`}
+                  to={`/${chapter.chapterNumber * 1 +
+                    1}?translations=${translations}`}
                 >
                   <LocaleFormattedMessage
                     id="chapter.next"
@@ -332,7 +351,7 @@ class Surah extends Component {
       currentVerse
     } = this.props; // eslint-disable-line no-shadow
 
-    return Object.values(verses).map(verse => (
+    return Object.values(verses).map(verse =>
       <Verse
         verse={verse}
         chapter={chapter}
@@ -349,7 +368,7 @@ class Surah extends Component {
         userAgent={options.userAgent}
         audio={options.audio}
       />
-    ));
+    );
   }
 
   renderLines() {
@@ -392,7 +411,8 @@ class Surah extends Component {
         <Helmet
           {...makeHeadTags({
             title: this.title(),
-            description: this.description()
+            description: this.description(),
+            image: this.ogImage()
           })}
           script={[
             {
@@ -420,7 +440,9 @@ class Surah extends Component {
           ]}
           style={[
             {
-              cssText: `.text-arabic{font-size: ${options.fontSize.arabic}rem;} .text-translation{font-size: ${options.fontSize.translation}rem;}` // eslint-disable-line max-len
+              cssText: `.text-arabic{font-size: ${options.fontSize
+                .arabic}rem;} .text-translation{font-size: ${options.fontSize
+                .translation}rem;}` // eslint-disable-line max-len
             }
           ]}
         />

--- a/src/containers/Surah/index.js
+++ b/src/containers/Surah/index.js
@@ -266,7 +266,6 @@ class Surah extends Component {
         this.getFirst() + 10 > chapter.versesCount
           ? chapter.versesCount
           : this.getFirst() + 10;
-
       return (
         <ul className="pager">
           <li className="text-center">

--- a/src/containers/Surah/index.js
+++ b/src/containers/Surah/index.js
@@ -184,10 +184,10 @@ class Surah extends Component {
     const hasAyahNumber = params.range && !isNaN(params.range);
 
     if (hasAyahNumber) {
-      return `https://og.tarteel.io/${chapter.chapterNumber}/${params.range}`;
+      return `https://quran-og-image.vercel.app/${chapter.chapterNumber}/${params.range}`;
     }
 
-    return `https://og.tarteel.io/${chapter.chapterNumber}`;
+    return `https://quran-og-image.vercel.app/${chapter.chapterNumber}`;
   }
 
   description() {


### PR DESCRIPTION
### Summary 
1. Removed the canonical url property `og:url` which made Facebook and other crawlers always fetch the meta tags for https://quran.com instead of the desired path.

2. Added dynamic open-graph images that fetch image previews based on the content.

### Test Plan
@mmahalwy I don't have the API running locally so haven't been able to test the changes. Let's get it up on staging and give it a test before we deploy it to prod. 

