### PR TITLE
fix: centering play icon

### DIFF
--- a/src/components/Audioplayer/style.scss
+++ b/src/components/Audioplayer/style.scss
@@ -41,6 +41,11 @@
     vertical-align: middle;
     padding-right: 20px;
     color: #939598;
+    display: flex;
+    align-items: center;
+    margin: 0 auto;
+    justify-content: center;
+    padding: 2px 0 0 2px;
   }
 }
 


### PR DESCRIPTION
before:
<img width="361" alt="image" src="https://user-images.githubusercontent.com/1161308/94987184-7caadf00-058e-11eb-9a22-7875f0a88fdf.png">

after:
<img width="355" alt="image" src="https://user-images.githubusercontent.com/1161308/94987231-dad7c200-058e-11eb-97a6-efd14eab480e.png">
